### PR TITLE
fix: auto-join meeting invites for signed-in users

### DIFF
--- a/BE/controllers/meeting.controller.ts
+++ b/BE/controllers/meeting.controller.ts
@@ -570,6 +570,76 @@ export const resolveMeetingGuestInvite = async (req: Request, res: Response) => 
 };
 
 /**
+ * GET /api/meeting/guest-invite/:token/join
+ * Authenticated endpoint: join a meeting using a guest invite token, but with the user's real identity.
+ *
+ * This is used to ensure "Login for full experience" lands in the meeting (not dashboard),
+ * and to auto-enter the meeting when a logged-in user opens an invite link.
+ */
+export const joinMeetingFromGuestInvite = async (req: any, res: Response) => {
+    try {
+        const { userId } = req.user || {};
+        const rawToken = String((req.params as any).token || '').trim();
+        if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+        if (!rawToken) return res.status(400).json({ error: 'token is required' });
+
+        const tokenHash = hashInviteToken(rawToken);
+        const invite = await MeetingGuestInvite.findOne({ tokenHash }).lean();
+        if (!invite) return res.status(404).json({ error: 'Invite not found' });
+        if (invite.revokedAt) return res.status(410).json({ error: 'Invite is no longer valid' });
+        if (new Date(invite.expiresAt).getTime() <= Date.now()) {
+            return res.status(410).json({ error: 'Invite has expired' });
+        }
+
+        const meeting = await MeetingThread.findById(invite.meetingThreadId).select(
+            'jitsiRoomName status conversationId groupChatId removedParticipants joinEvents participants startedBy',
+        );
+        if (!meeting || meeting.status !== 'active') {
+            return res.status(410).json({ error: 'Meeting is no longer active' });
+        }
+        if (isRemovedFromMeeting(meeting, String(userId))) {
+            return res.status(403).json({ error: 'You were removed from this active call by a moderator' });
+        }
+
+        const me = await User.findById(userId).select('_id username email image');
+        if (!me) return res.status(404).json({ error: 'User not found' });
+
+        const auth = await canUserJoinMeeting(meeting, String(userId));
+        if (!auth.allowed) return res.status(403).json({ error: 'You do not have access to this meeting' });
+
+        const jitsiUrl = buildSignedJitsiUrl(String(meeting.jitsiRoomName), me, {
+            moderator: auth.moderator,
+            guest: false,
+        });
+
+        meeting.joinEvents = Array.isArray(meeting.joinEvents) ? meeting.joinEvents : [];
+        meeting.joinEvents.push({
+            userId: me._id,
+            joinedAt: new Date(),
+            source: 'guest-invite',
+        });
+        if (!Array.isArray(meeting.participants)) {
+            meeting.participants = [];
+        }
+        if (!meeting.participants.some((p: any) => normalizeId(p) === normalizeId(me._id))) {
+            meeting.participants.push(me._id);
+        }
+        await meeting.save();
+
+        return res.status(200).json({
+            success: true,
+            meetingThreadId: String(invite.meetingThreadId),
+            jitsiRoomName: String(meeting.jitsiRoomName),
+            role: auth.moderator ? 'moderator' : 'participant',
+            jitsiUrl,
+        });
+    } catch (err: any) {
+        console.error('[meeting.joinFromGuestInvite]', err.message);
+        return res.status(500).json({ error: err.message });
+    }
+};
+
+/**
  * GET /api/meeting/:meetingThreadId/join
  * Return signed Jitsi URL for authenticated participants.
  */

--- a/BE/routes/meetingRoutes.ts
+++ b/BE/routes/meetingRoutes.ts
@@ -11,6 +11,7 @@ import {
     submitMeetingRating,
     createMeetingGuestInvite,
     resolveMeetingGuestInvite,
+    joinMeetingFromGuestInvite,
     getMeetingJoinInfo,
     revokeMeetingParticipant,
 } from '../controllers/meeting.controller';
@@ -22,6 +23,7 @@ router.post('/rate', requireAuth(false), submitMeetingRating);
 router.post('/guest-invite', requireAuth(false), createMeetingGuestInvite);
 router.post('/revoke-participant', requireAuth(false), revokeMeetingParticipant);
 router.get('/guest-invite/:token', resolveMeetingGuestInvite);
+router.get('/guest-invite/:token/join', requireAuth(false), joinMeetingFromGuestInvite);
 router.get('/:meetingThreadId/join', requireAuth(false), getMeetingJoinInfo);
 router.get('/:meetingThreadId/rating-state', requireAuth(false), getMeetingRatingState);
 router.get('/:meetingThreadId', requireAuth(false), getMeetingThread);

--- a/FE/src/api/chatApi.ts
+++ b/FE/src/api/chatApi.ts
@@ -382,3 +382,21 @@ export const resolveMeetingGuestInvite = async (token: string): Promise<{
         return { success: false, error: err?.response?.data?.error || err.message };
     }
 };
+
+/** Join meeting using a guest invite token, but as an authenticated user. */
+export const joinMeetingFromGuestInvite = async (token: string): Promise<{
+    success?: boolean;
+    meetingThreadId?: string;
+    jitsiRoomName?: string;
+    role?: string;
+    jitsiUrl?: string;
+    error?: string;
+}> => {
+    try {
+        const res = await api.get(`meeting/guest-invite/${encodeURIComponent(token)}/join`);
+        return res.data;
+    } catch (err: any) {
+        console.error('[chatApi.joinMeetingFromGuestInvite]', err.message);
+        return { success: false, error: err?.response?.data?.error || err.message };
+    }
+};

--- a/FE/src/pages/MeetingGuestInvite.test.tsx
+++ b/FE/src/pages/MeetingGuestInvite.test.tsx
@@ -20,6 +20,11 @@ describe("MeetingGuestInvite", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.mocked(chatApi.joinMeetingFromGuestInvite as any).mockResolvedValue({
+      success: false,
+      error: "No access",
+    });
     vi.mocked(chatApi.resolveMeetingGuestInvite).mockResolvedValue({
       success: true,
       jitsiUrl: "https://meet.wisdomlinked.com/room-abc",
@@ -38,16 +43,34 @@ describe("MeetingGuestInvite", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/login?redirect=%2Fmeeting%2Finvite%2Finvite-token-123");
   });
 
-  it("routes signed-in users to login from full-experience CTA", async () => {
+  it("auto-enters the meeting for signed-in users (skips invite page)", async () => {
+    const replaceSpy = vi.fn();
+    vi.stubGlobal("location", { ...window.location, replace: replaceSpy });
+    vi.mocked(chatApi.joinMeetingFromGuestInvite as any).mockResolvedValue({
+      success: true,
+      jitsiUrl: "https://meet.wisdomlinked.com/authed-room",
+    });
     window.localStorage.setItem("currentUser", JSON.stringify({ email: "c@x.com", role: "customer" }));
+
+    render(<MeetingGuestInvite />);
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledWith("https://meet.wisdomlinked.com/authed-room");
+    });
+  });
+
+  it("falls back to guest invite UI when signed-in user cannot join as participant", async () => {
+    window.localStorage.setItem("currentUser", JSON.stringify({ email: "c@x.com", role: "customer" }));
+    vi.mocked(chatApi.joinMeetingFromGuestInvite as any).mockResolvedValue({
+      success: false,
+      error: "You do not have access to this meeting",
+    });
+
     render(<MeetingGuestInvite />);
 
     await waitFor(() => {
       expect(screen.getByText("Continue as guest")).toBeInTheDocument();
     });
-
-    fireEvent.click(screen.getByText("Login for full experience"));
-    expect(mockNavigate).toHaveBeenCalledWith("/login?redirect=%2Fmeeting%2Finvite%2Finvite-token-123");
   });
 });
 

--- a/FE/src/pages/MeetingGuestInvite.tsx
+++ b/FE/src/pages/MeetingGuestInvite.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { resolveMeetingGuestInvite } from "../api/chatApi";
+import { joinMeetingFromGuestInvite, resolveMeetingGuestInvite } from "../api/chatApi";
 
 export default function MeetingGuestInvite() {
   const { token } = useParams();
@@ -18,6 +18,29 @@ export default function MeetingGuestInvite() {
         setLoading(false);
         return;
       }
+
+      // If the user is already logged in, skip the invite landing page and enter the meeting directly.
+      const stored = localStorage.getItem("currentUser");
+      const currentUser = (() => {
+        try {
+          return stored && stored !== "undefined" ? JSON.parse(stored) : null;
+        } catch {
+          return null;
+        }
+      })();
+      const isSignedIn = Boolean(currentUser?.email);
+
+      if (isSignedIn) {
+        const joinRes = await joinMeetingFromGuestInvite(token);
+        if (cancelled) return;
+        if (joinRes?.success && joinRes?.jitsiUrl) {
+          // Replace current tab: user shouldn't see the invite screen at all.
+          window.location.replace(joinRes.jitsiUrl);
+          return;
+        }
+        // If user doesn't actually have access, fall back to guest flow UI.
+      }
+
       const res = await resolveMeetingGuestInvite(token);
       if (cancelled) return;
       if (!res?.success || !res?.jitsiUrl) {


### PR DESCRIPTION
Ensure guest invite links send authenticated users directly into the meeting and keep the full-experience login flow from falling back to the dashboard.

