### PR TITLE
fixed login redirect issue

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -228,12 +228,12 @@ function App() {
         }
       }
       if (locationUrl) {
-        navigate(locationUrl)
+        navigate(locationUrl, {replace: true})
       } else {
         if (userDetails?.role === 'customer') {
-          navigate('/user/studentdashboard')
+          navigate('/user/studentdashboard', {replace: true})
         } else {
-          navigate('/user/' + userDetails?.role + "dashboard")
+          navigate('/user/' + userDetails?.role + "dashboard",{replace: true})
         }
       }
     }

--- a/FE/src/pages/WLLogin.tsx
+++ b/FE/src/pages/WLLogin.tsx
@@ -155,15 +155,15 @@ export default function WLLogin() {
                 dispatch({ type: actionTypes.authenticate, payload: response.userDetails });
                 dispatch(showSuccessAlert(`Hi, ${response.userDetails.username} 👋. Welcome back.`));
                 if (redirectPath.startsWith("/")) {
-                    navigate(redirectPath);
+                    navigate(redirectPath, {replace: true});
                     return;
                 }
                 // Navigate to the correct dashboard based on role
                 const role = response.userDetails.role;
                 if (role === 'customer') {
-                    navigate('/user/studentdashboard');
+                    navigate('/user/studentdashboard',{replace: true});
                 } else {
-                    navigate('/user/' + role + 'dashboard');
+                    navigate('/user/' + role + 'dashboard',{replace: true});
                 }
             } else {
                 setFormError(response.error || 'Verification failed. Please try again.');


### PR DESCRIPTION
After a successful login, pressing the browser Back button was taking users back to the login page instead of the page before login.

**Root cause:** navigate() after OTP verification was pushing /login onto the browser history stack, so Back navigated to it.

**Fix:** Changed all post-login navigate() calls in WLLogin.tsx and App.tsx to use { replace: true }, which replaces the /login history entry rather than stacking on top of it.