### PR TITLE
fix: booking timezone conversion, calendar display, and session lengt…

### DIFF
--- a/FE/src/components/dashboard/ExpertProfile.tsx
+++ b/FE/src/components/dashboard/ExpertProfile.tsx
@@ -878,6 +878,7 @@ export default function ExpertProfile({
                       <StudentExpertBookingPicker
                         expert={expertDetails}
                         onSlotSelected={handleSlotPicked}
+                        initialDuration={sessionDurationMinutes}
                       />
                     )}
                   </div>

--- a/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
+++ b/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
@@ -13,6 +13,7 @@ import {
   detectUserTimeZone,
   resolveViewerTimeZone,
   toYMDInTimeZone,
+  getTimezoneOffsetHalfHours,
 } from '../../utils/schedulingTimezone';
 import { normalizeExpertPrice } from '../../utils/schedulingSlots';
 import type { BookingDisplayTimeZoneMode } from '../../types/scheduling';
@@ -21,6 +22,7 @@ type Props = {
   expert: any;
   onSlotSelected: (start: Date, end: Date, duration: number) => void;
   hidePriceInDurationSelection?: boolean;
+  initialDuration?: number;
 };
 
 const DURATIONS = [30, 60, 90] as const;
@@ -62,7 +64,7 @@ const DURATION_OPTIONS = DURATIONS.map((d) => ({
 
 const calendarFormats = {
   weekdayFormat: (date: Date, culture?: string, localizer?: any) =>
-    localizer.format(date, 'ddd', culture),
+    localizer.format(date, 'EEE', culture),
 };
 
 function expertDisplayName(expert: any): string {
@@ -89,6 +91,7 @@ export default function StudentExpertBookingPicker({
   expert,
   onSlotSelected,
   hidePriceInDurationSelection = false,
+  initialDuration = 30,
 }: Props) {
   const { auth: { userDetails } } = useAppSelector((state: any) => state);
 
@@ -98,7 +101,8 @@ export default function StudentExpertBookingPicker({
   const [tzMode, setTzMode] = useState<BookingDisplayTimeZoneMode>('mine');
   const [customTz, setCustomTz] = useState(detectUserTimeZone());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [duration, setDuration] = useState(30);
+  const [duration, setDuration] = useState(initialDuration ?? 30);
+  useEffect(() => {setDuration(initialDuration);}, [initialDuration]);
   const [timeSlots, setTimeSlots] = useState<number[]>([]);
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<number | null>(null);
   const [filterSlotIndex, setFilterSlotIndex] = useState(-1);
@@ -140,7 +144,14 @@ export default function StudentExpertBookingPicker({
 
   const getAvailableTimeSlots = useCallback(
     (day: Date, dur: number) => {
-      const dayStartTime = new Date(day).getTime();
+      
+      // Gets the reference dayStartTime from viewers time zone
+      const browserTz = detectUserTimeZone(); // matches what RBC uses
+      const dateStr = toYMDInTimeZone(day, browserTz); // correct calendar date
+      const [yr, mo, dy] = dateStr.split('-').map(Number);
+      const tzOffset = getTimezoneOffsetHalfHours(viewerTz, day);
+      const dayStartTime = Date.UTC(yr, mo - 1, dy) + tzOffset * 30 * 60 * 1000;
+
       const dayEndTime = dayStartTime + 24 * 60 * 60 * 1000 - 1;
       const start = new Date(dayStartTime);
       const end = new Date(dayEndTime);
@@ -234,6 +245,19 @@ export default function StudentExpertBookingPicker({
           },
         };
       }
+      // Highlight selected date
+      if (selectedDate) {
+          const selMidnight = new Date(selectedDate).setHours(0, 0, 0, 0);
+          if (date.getTime() === selMidnight) {
+            return {
+              style: {
+                backgroundColor: '#59a8f7',
+                color: '#fff',
+                cursor: 'pointer',
+              },
+            };
+          }
+        }
 
       const hasEvent = events.some(
         (event) =>
@@ -263,7 +287,7 @@ export default function StudentExpertBookingPicker({
 
       return { style: { backgroundColor, cursor: cursorStyle } };
     },
-    [events, filterSlotIndex, duration, getAvailableTimeSlots, expert, expertTz],
+    [events, filterSlotIndex, duration, getAvailableTimeSlots, expert, expertTz, selectedDate],
   );
 
   const calendarComponents = useMemo(

--- a/FE/src/components/scheduling/BookingTimeZoneControl.tsx
+++ b/FE/src/components/scheduling/BookingTimeZoneControl.tsx
@@ -54,7 +54,7 @@ const BookingTimeZoneControl: React.FC<BookingTimeZoneControlProps> = ({
 
 }) => {
 
-  const mine = studentTimeZone || detectUserTimeZone();
+  const mine = detectUserTimeZone();
 
   const isStudent = appearance === 'student';
 

--- a/FE/src/pages/Dashboard/_ExpertDashboard/availability.tsx
+++ b/FE/src/pages/Dashboard/_ExpertDashboard/availability.tsx
@@ -558,7 +558,7 @@ const AvailabilityPage: React.FC = () => {
             {/* Session Duration */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">
-                Session Duration
+                Minimum Session Duration
               </label>
               <div className="inline-flex rounded-full bg-gray-50 p-1 text-xs font-medium text-gray-600">
                 {SESSION_DURATIONS.map((duration) => {

--- a/FE/src/utils/schedulingTimezone.test.ts
+++ b/FE/src/utils/schedulingTimezone.test.ts
@@ -30,7 +30,7 @@ describe('schedulingTimezone', () => {
   });
 
   it('resolveViewerTimeZone respects mode', () => {
-    expect(resolveViewerTimeZone('mine', 'Asia/Kolkata', 'UTC')).toBe('Asia/Kolkata');
+    expect(resolveViewerTimeZone('mine', 'Asia/Kolkata', 'UTC')).toBe(detectUserTimeZone());
     expect(resolveViewerTimeZone('expert', 'Asia/Kolkata', 'UTC')).toBe('UTC');
     expect(resolveViewerTimeZone('custom', 'Asia/Kolkata', 'UTC', 'Europe/London')).toBe(
       'Europe/London',

--- a/FE/src/utils/schedulingTimezone.ts
+++ b/FE/src/utils/schedulingTimezone.ts
@@ -64,7 +64,7 @@ export function convertExpertSlotsToViewer(
   if (!expertSlots?.length) return [];
   const expertOffset = getTimezoneOffsetHalfHours(expertTz || 'UTC', date);
   const viewerOffset = getTimezoneOffsetHalfHours(viewerTz || 'UTC', date);
-  const shift = viewerOffset - expertOffset;
+  const shift = expertOffset - viewerOffset;
   const shifted = expertSlots.map((slot) => (slot + shift + 48) % 48);
   return [...new Set(shifted)].sort((a, b) => a - b);
 }
@@ -77,7 +77,7 @@ export function resolveViewerTimeZone(
 ): string {
   if (mode === 'expert') return expertTz || 'UTC';
   if (mode === 'custom' && customTz) return customTz;
-  return studentTz || detectUserTimeZone();
+  return detectUserTimeZone();
 }
 
 export function formatSlotLabel(slotIndex: number, date: Date, timeZone: string): string {


### PR DESCRIPTION
- Fix slot shift sign bug in convertExpertSlotsToViewer (expertOffset - viewerOffset)
- Fix dayStartTime to use viewerTz midnight in getAvailableTimeSlots
- Fix My timezone button to use actual browser timezone via detectUserTimeZone()
- Fix calendar weekday headers showing date numbers instead of day names (ddd -> EEE)
- Add selected date highlight in dayStyleGetter
- Sync session length between sidebar and booking modal via initialDuration prop