### PR TITLE
fix(timezone): capture browser timezone at registration and OAuth

### DIFF
--- a/BE/controllers/auth.controller.ts
+++ b/BE/controllers/auth.controller.ts
@@ -211,6 +211,7 @@ const register = async (req: Request, res: Response) => {
         const password = safeParse(req.body.password)
         const timeSlots = safeParse(req.body.timeSlots)
         const specialNote = safeParse(req.body.specialNote)
+        const timeZone = safeParse(req.body.timeZone) || 'UTC'
         
         const keywords = getArrayField(req, 'keywords');
         const services = getArrayField(req, 'services');
@@ -294,6 +295,7 @@ const register = async (req: Request, res: Response) => {
             timeSlots,
             price: 10,
             confirmCode,
+            timeZone,
             ...(specialNote && { specialNote })
         });
 
@@ -427,6 +429,7 @@ const verifyRegistration = async (req: Request, res: Response) => {
             role: pendingUser.role,
             timeSlots: pendingUser.timeSlots,
             price: pendingUser.price,
+            timeZone: pendingUser.timeZone || 'UTC',
             ...(pendingUser.specialNote && { specialNote: pendingUser.specialNote })
         });
 

--- a/BE/models/PendingUser.ts
+++ b/BE/models/PendingUser.ts
@@ -40,6 +40,7 @@ const pendingUserSchema = new mongoose.Schema(
         price: [{ type: Number, default: 5 }],
         rating: { type: Number, default: 0 },
         specialNote: { type: String },
+        timeZone: { type: String, default: 'UTC' },
     },
     { timestamps: true }
 );

--- a/BE/routes/authRoutes.ts
+++ b/BE/routes/authRoutes.ts
@@ -105,10 +105,11 @@ const oauthCallback = async (req: any, res: any) => {
         const user = result.user || result;
         const isNew = result.isNew || false;
 
-        // Read role + redirect from OAuth state parameter (Google/Facebook) or session (Twitter)
+        // Read role + redirect + timezone from OAuth state parameter (Google/Facebook) or session (Twitter)
         const rawState = String(req.query.state || '').trim();
         let role: string | null = (req.session && req.session.oauthRole) || null;
         let redirectPath = '';
+        let timezone = '';
         if (rawState) {
             try {
                 const parsed = JSON.parse(decodeURIComponent(rawState));
@@ -118,6 +119,9 @@ const oauthCallback = async (req: any, res: any) => {
                     }
                     if (typeof parsed.redirect === 'string' && parsed.redirect.trim()) {
                         redirectPath = parsed.redirect.trim();
+                    }
+                    if (typeof parsed.timezone === 'string' && parsed.timezone.trim()) {
+                        timezone = parsed.timezone.trim();
                     }
                 } else {
                     role = rawState;
@@ -139,6 +143,11 @@ const oauthCallback = async (req: any, res: any) => {
         // Set role for NEW users from registration pages only
         if (isNew && role && (role === 'expert' || role === 'customer')) {
             user.role = role;
+        }
+
+        // Always sync browser timezone — DB defaults to 'UTC' but real location comes from the client
+        if (timezone) {
+            user.timeZone = timezone;
         }
         
         // Block existing users from switching roles via OAuth re-registration
@@ -204,9 +213,11 @@ const oauthCallback = async (req: any, res: any) => {
 router.get('/google', (req: any, res: any, next: any) => {
     const role = req.query.role || 'login';
     const redirectPath = String(req.query.redirect || '').trim();
+    const timezone = String(req.query.timezone || '').trim();
     const state = encodeURIComponent(JSON.stringify({
         role,
         redirect: redirectPath.startsWith('/') ? redirectPath : '',
+        timezone,
     }));
     passport.authenticate('google', { scope: ['profile', 'email'], state, session: false })(req, res, next);
 });

--- a/FE/src/components/SocialAuthBlock.tsx
+++ b/FE/src/components/SocialAuthBlock.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { detectUserTimeZone } from '../utils/schedulingTimezone';
 
 const BASE_URL = (process.env.REACT_APP_API_BASE_URL || '').replace(/\/$/, '');
 function getAuthRedirectUrl(provider: string, role?: string, redirect?: string) {
@@ -8,6 +9,7 @@ function getAuthRedirectUrl(provider: string, role?: string, redirect?: string) 
   const params = new URLSearchParams();
   if (role) params.set('role', role);
   if (redirect) params.set('redirect', redirect);
+  params.set('timezone', detectUserTimeZone());
   const q = params.toString();
   return q ? `${base}?${q}` : base;
 }

--- a/FE/src/pages/WLCustomerRegister.tsx
+++ b/FE/src/pages/WLCustomerRegister.tsx
@@ -203,6 +203,7 @@ export default function WLCustomerRegister() {
                 phoneNumber: form.countryCode + form.phone,
                 email: form.email,
                 password: form.password,
+                timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
                 ...(form.specialNote.trim() && { specialNote: form.specialNote.trim() })
             };
             const response = await callApi('POST', 'auth/register', data, undefined, {

--- a/FE/src/pages/WLExpertRegister.tsx
+++ b/FE/src/pages/WLExpertRegister.tsx
@@ -215,6 +215,7 @@ export default function WLExpertRegister() {
                 email: form.email,
                 password: form.password,
                 timeSlots: [],
+                timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
                 ...(form.specialNote.trim() && { specialNote: form.specialNote.trim() })
             };
             const response = await callApi('POST', 'auth/register', data, form.resumeFile || undefined, {


### PR DESCRIPTION
- Persist timeZone on PendingUser and carry it through verifyRegistration
- Send detected browser timezone from customer/expert register forms
- Pass timezone through OAuth state and sync it on the user record

**Note:**
- Previously, when a user logged in / signed up with Google, their timezone defaulted to **UTC**. With this fix, the timezone is detected from the browser and now shows **correctly on both the expert dashboard and the student dashboard**
- PFA testing notes: https://docs.google.com/document/d/1u96D4ITDZ1EkTK_YAwgw-m3xHZIhpnKli3CO1JKWjqQ/edit?tab=t.y0oluhqg0vjy [Go to time conversion tab]

<img width="401" height="699" alt="image" src="https://github.com/user-attachments/assets/0928781c-490e-4be3-ac68-850cb5f863d8" />
