### PR TITLE
fix(booking): reopen calendar modal and accept 1:1 without false errors

### DIFF
--- a/BE/controllers/groupChat.controller.ts
+++ b/BE/controllers/groupChat.controller.ts
@@ -1070,7 +1070,7 @@ const addMemberToPendingGroup = async (req, res) => {
 
 const acceptIndividualAppointment = async (req, res) => {
     try {
-        const { userId } = req.user;
+        const { userId, role } = req.user;
         const { groupChatId, payment_intent } = req.body;
 
         const groupChat = await GroupChat.findOne({ _id: groupChatId });
@@ -1079,9 +1079,7 @@ const acceptIndividualAppointment = async (req, res) => {
             return res.status(404).send("Sorry, the group chat doesn't exist");
         }
 
-        let customer, expert;
-
-        if (userId.role === 'customer') {
+        if (role === 'customer') {
             const expectedCents = dollarsToCents(groupChat.price);
             let paymentIntentSucceeded_test: any = false;
             let paymentIntentSucceeded_live: any = false;
@@ -1099,7 +1097,7 @@ const acceptIndividualAppointment = async (req, res) => {
                     currency: charge.currency,
                     description: groupChat.name,
                     paymentIntent: payment_intent,
-                    customer: userId.toString(),
+                    customer: String(userId),
                     expert: groupChat.admin.toString(),
                     groupChat: groupChatId,
                 })
@@ -1109,14 +1107,43 @@ const acceptIndividualAppointment = async (req, res) => {
         groupChat.status = 'active';
         await groupChat.save();
 
-        let user1 = await User.findById(userId);
-        let user2 = await User.findById(groupChat.createdBy);
+        const expertUser = await User.findById(userId);
+        const customerUser = await User.findById(groupChat.createdBy);
 
-        sendEmailMeetingAcceptance(user2.email, user2.username, groupChat.name, groupChat.start, groupChat.duration, user2.timeZone);
-
-
-        scheduleEmailReminder(user1.email, user1.username, groupChat.name, groupChat.start, groupChat.duration, user1.timeZone);
-        scheduleEmailReminder(user2.email, user2.username, groupChat.name, groupChat.start, groupChat.duration, user2.timeZone);
+        try {
+            if (customerUser?.email) {
+                await sendEmailMeetingAcceptance(
+                    customerUser.email,
+                    customerUser.username,
+                    groupChat.name,
+                    groupChat.start,
+                    groupChat.duration,
+                    customerUser.timeZone,
+                );
+            }
+            if (expertUser?.email) {
+                await scheduleEmailReminder(
+                    expertUser.email,
+                    expertUser.username,
+                    groupChat.name,
+                    groupChat.start,
+                    groupChat.duration,
+                    expertUser.timeZone,
+                );
+            }
+            if (customerUser?.email) {
+                await scheduleEmailReminder(
+                    customerUser.email,
+                    customerUser.username,
+                    groupChat.name,
+                    groupChat.start,
+                    groupChat.duration,
+                    customerUser.timeZone,
+                );
+            }
+        } catch (notifyErr) {
+            console.error('[acceptIndividualAppointment] notification failed:', notifyErr?.message || notifyErr);
+        }
 
         return res.status(200).send("Group chat accepted successfully!");
 

--- a/BE/services/notifications.ts
+++ b/BE/services/notifications.ts
@@ -36,7 +36,7 @@ sendEmailUserAccountApproved = (targetEmail, userName) => {
     sendNotificationEmail(targetEmail, subject, html);
 }
 
-scheduleEmailReminder = (targetEmail, userName, title,start, duration, timeZone) => {
+scheduleEmailReminder = async (targetEmail, userName, title,start, duration, timeZone) => {
     subject = "You have a meeting: " + title;
     // timezone is like "America/New_York" so we need to send the date as per time zone
     const options = { timeZone: timeZone || "UTC" };
@@ -54,10 +54,10 @@ scheduleEmailReminder = (targetEmail, userName, title,start, duration, timeZone)
             <a href="${website_url}">Visit Website</a>
         </p>
     `;
-    sendNotificationEmail(targetEmail, subject, html, scheduledTime);
+    return sendNotificationEmail(targetEmail, subject, html, scheduledTime);
 }
 
-sendEmailMeetingAcceptance = (targetEmail, userName, title,start, duration, timeZone) => {
+sendEmailMeetingAcceptance = async (targetEmail, userName, title,start, duration, timeZone) => {
     subject = "Meeting accepted :" + title;
     const options = { timeZone: timeZone || "UTC" };
     const date = new Date(start).toLocaleString("en-US", options);
@@ -71,7 +71,7 @@ sendEmailMeetingAcceptance = (targetEmail, userName, title,start, duration, time
             <a href="${website_url}">Visit Website</a>
         </p>
     `;
-    sendNotificationEmail(targetEmail, subject, html);
+    return sendNotificationEmail(targetEmail, subject, html);
 }
 
 sendEmailMeetingRequestToExpert = (targetEmail, expertName, name,start, duration,price, newEvent, timeZone) => {

--- a/BE/tests/acceptIndividualAppointment.test.ts
+++ b/BE/tests/acceptIndividualAppointment.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const notificationsPath = require.resolve('../services/notifications');
+const groupChatPath = require.resolve('../controllers/groupChat.controller');
+
+test('acceptIndividualAppointment returns 200 when notifications fail after save', async () => {
+    const GroupChat = require('../models/GroupChat');
+    const User = require('../models/User');
+
+    const originalFindOne = GroupChat.findOne;
+    const originalFindById = User.findById;
+    const originalNotifications = require('../services/notifications');
+
+    const savedGroup = {
+        _id: 'gc-accept-1',
+        name: '1:1 Session',
+        start: new Date('2026-07-01T18:00:00.000Z'),
+        end: new Date('2026-07-01T19:00:00.000Z'),
+        duration: 60,
+        price: 50,
+        admin: 'expert-1',
+        createdBy: 'student-1',
+        status: 'pending',
+        save: async function save() {
+            this.status = 'active';
+            return this;
+        },
+    };
+
+    try {
+        GroupChat.findOne = async () => savedGroup;
+        User.findById = async (id: string) => {
+            if (String(id) === 'expert-1') {
+                return {
+                    _id: 'expert-1',
+                    email: 'expert@test.com',
+                    username: 'Expert',
+                    timeZone: 'UTC',
+                };
+            }
+            if (String(id) === 'student-1') {
+                return {
+                    _id: 'student-1',
+                    email: 'student@test.com',
+                    username: 'Student',
+                    timeZone: 'UTC',
+                };
+            }
+            return null;
+        };
+
+        require.cache[notificationsPath] = {
+            id: notificationsPath,
+            filename: notificationsPath,
+            loaded: true,
+            exports: {
+                ...originalNotifications,
+                sendEmailMeetingAcceptance: async () => {
+                    throw new Error('SendGrid unavailable');
+                },
+                scheduleEmailReminder: async () => {
+                    throw new Error('SendGrid unavailable');
+                },
+            },
+        };
+        delete require.cache[groupChatPath];
+        const groupController = require('../controllers/groupChat.controller');
+
+        const req: any = {
+            user: { userId: 'expert-1', role: 'expert' },
+            body: { groupChatId: 'gc-accept-1' },
+        };
+        const res: any = {
+            statusCode: 200,
+            body: null,
+            status(code: number) {
+                this.statusCode = code;
+                return this;
+            },
+            send(payload: any) {
+                this.body = payload;
+                return this;
+            },
+        };
+
+        await groupController.acceptIndividualAppointment(req, res);
+
+        assert.equal(res.statusCode, 200);
+        assert.equal(savedGroup.status, 'active');
+        assert.match(String(res.body), /accepted successfully/i);
+    } finally {
+        GroupChat.findOne = originalFindOne;
+        User.findById = originalFindById;
+        require.cache[notificationsPath] = {
+            id: notificationsPath,
+            filename: notificationsPath,
+            loaded: true,
+            exports: originalNotifications,
+        };
+        delete require.cache[groupChatPath];
+    }
+});

--- a/FE/src/components/dashboard/StudentExpertBookingPicker.test.tsx
+++ b/FE/src/components/dashboard/StudentExpertBookingPicker.test.tsx
@@ -352,9 +352,25 @@ describe('StudentExpertBookingPicker', () => {
       </Provider>,
     );
 
-    // A declined booking overlapping the 15th must not block it.
     expect(screen.getByRole('button', { name: '15' })).toHaveClass(
       'cursor-pointer',
     );
+  });
+
+  it('reopens time modal after cancel closes it (calendar remount)', () => {
+    render(
+      <Provider store={store}>
+        <StudentExpertBookingPicker expert={expert} onSlotSelected={vi.fn()} />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTestId('mock-select-day'));
+    expect(screen.getByText('Choose a time')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Choose a time')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mock-select-day'));
+    expect(screen.getByText('Choose a time')).toBeInTheDocument();
   });
 });

--- a/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
+++ b/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
@@ -154,6 +154,8 @@ export default function StudentExpertBookingPicker({
   const [events, setEvents] = useState<any[]>([]);
   const [rawExpertSlots, setRawExpertSlots] = useState<number[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
+  /** Remount calendar after closing time modal so the same day can be clicked again (RBC keeps slot selected). */
+  const [calendarResetKey, setCalendarResetKey] = useState(0);
   const [tzMode, setTzMode] = useState<BookingDisplayTimeZoneMode>('mine');
   const [customTz, setCustomTz] = useState(detectUserTimeZone());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -488,6 +490,12 @@ export default function StudentExpertBookingPicker({
     };
   };
 
+  const closeTimeModal = useCallback(() => {
+    setModalOpen(false);
+    setSelectedTimeSlot(null);
+    setCalendarResetKey((k) => k + 1);
+  }, []);
+
   const confirmSlot = useCallback(
     (slot: number, dayOverride?: Date) => {
       const day = dayOverride ?? selectedDate;
@@ -496,7 +504,7 @@ export default function StudentExpertBookingPicker({
       const end = new Date(start.getTime() + duration * 60 * 1000);
       setConfirmedSlotStart(start);
       onSlotSelected(start, end, duration);
-      setModalOpen(false);
+      closeTimeModal();
       if (filterSlotIndex >= 0) {
         onFilterSlotConfirmed?.();
       }
@@ -508,6 +516,7 @@ export default function StudentExpertBookingPicker({
       onSlotSelected,
       filterSlotIndex,
       onFilterSlotConfirmed,
+      closeTimeModal,
     ],
   );
 
@@ -640,6 +649,7 @@ export default function StudentExpertBookingPicker({
 
       <div className="overflow-hidden rounded-xl border border-[#E5E2DB] bg-white p-2">
         <Calendar
+          key={calendarResetKey}
           className="studentBookingCalendar min-h-[380px] text-[#1A3A4A]"
           views={['month']}
           selectable
@@ -680,13 +690,13 @@ export default function StudentExpertBookingPicker({
             type="button"
             className="absolute inset-0 bg-[#1A3A4A]/40 backdrop-blur-sm"
             aria-label="Close"
-            onClick={() => setModalOpen(false)}
+            onClick={closeTimeModal}
           />
           <div className="relative w-full max-w-md rounded-2xl border border-[#E5E2DB] bg-white p-6 shadow-[0_20px_50px_rgba(26,58,74,0.15)]">
             <button
               type="button"
               className="absolute right-4 top-4 rounded-lg p-1 text-[#7A7A72] hover:bg-[#F5F3EF]"
-              onClick={() => setModalOpen(false)}
+              onClick={closeTimeModal}
             >
               <X className="h-5 w-5" />
             </button>
@@ -747,7 +757,7 @@ export default function StudentExpertBookingPicker({
             <div className="mt-6 flex gap-3">
               <button
                 type="button"
-                onClick={() => setModalOpen(false)}
+                onClick={closeTimeModal}
                 className="flex-1 rounded-[4px] border border-[#E5E2DB] py-2.5 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
               >
                 Cancel

--- a/FE/src/pages/Dashboard/selectDateTime.tsx
+++ b/FE/src/pages/Dashboard/selectDateTime.tsx
@@ -40,6 +40,7 @@ const SelectDateTime = ({
     const [rawExpertSlots, set_rawExpertSlots] = useState<number[]>([])
 
     const [modalShow, set_modalShow] = useState(false)
+    const [calendarResetKey, setCalendarResetKey] = useState(0)
     const [tzMode, setTzMode] = useState<BookingDisplayTimeZoneMode>('mine');
     const [customTz, setCustomTz] = useState(detectUserTimeZone());
 
@@ -234,6 +235,12 @@ const SelectDateTime = ({
         [events, selectedIndex, duration, getAvailableTimeSlots, viewerTz]
     );
 
+    const closeTimeModal = () => {
+        set_modalShow(false);
+        set_selectedTimeSlot(undefined);
+        setCalendarResetKey((k) => k + 1);
+    };
+
     const saveAndNext = (slotOverride?: number) => {
         const slot = slotOverride !== undefined ? slotOverride : selectedTimeSlot;
         if (!selectedDate || slot === undefined || slot === null) {
@@ -377,6 +384,7 @@ const SelectDateTime = ({
             </div>
 
             <Calendar
+                key={calendarResetKey}
                 className="customerSelectDateTimeCalendar !h min-h-[400px] pt-1 pb-6 text-white"
                 views={["month"]}
                 selectable
@@ -391,11 +399,11 @@ const SelectDateTime = ({
             {
                 modalShow ?
                     <div className={`absolute top-0 left-0 w-full h-full bg-white bg-opacity-10 backdrop-blur-sm z-10 flex items-center justify-center p-8`}>
-                        <div className="absolute top-0 left-0 w-full h-full cursor-pointer" onClick={() => set_modalShow(false)} />
+                        <div className="absolute top-0 left-0 w-full h-full cursor-pointer" onClick={closeTimeModal} />
                         <div className="w-full max-w-[400px] bg-black rounded-lg text-white p-6 relative">
                             <button
                                 className="absolute right-4 top-4 rounded-md hover:bg-grey"
-                                onClick={() => set_modalShow(false)}
+                                onClick={closeTimeModal}
                             >
                                 <CloseIcon />
                             </button>
@@ -431,7 +439,7 @@ const SelectDateTime = ({
                             <div className="w-full h-10 flex justify-between">
                                 <button
                                     className="w-[calc(50%-8px)] rounded-lg border border-lightgrey flex items-center justify-center"
-                                    onClick={() => set_modalShow(false)}
+                                    onClick={closeTimeModal}
                                 >
                                     Cancel
                                 </button>


### PR DESCRIPTION
## Summary
Fixes two booking bugs from QA:

1. **Calendar time modal** — Closing the modal left the date selected in `react-big-calendar`, so clicking the same date again did nothing. Reset selection on close via `calendarResetKey` in `StudentExpertBookingPicker` and legacy `selectDateTime`.
2. **Expert Accept 1:1** — Appointment saved but UI showed an error when notification/email failed afterward. Save completes first; notification failures are logged only. Also fixed `req.user.role` and missing user null checks.

## Files
- `FE/src/components/dashboard/StudentExpertBookingPicker.tsx`
- `FE/src/pages/Dashboard/selectDateTime.tsx`
- `BE/controllers/groupChat.controller.ts`
- `BE/services/notifications.ts`
- `BE/tests/acceptIndividualAppointment.test.ts`
- `FE/src/components/dashboard/StudentExpertBookingPicker.test.tsx`

## Merge note
This change is already live on `staging` (`d456997e`). This PR is the review diff against the commit immediately before that fix. After approval, no extra deploy is required unless `staging` is rolled back first.

## Test plan
- [ ] Student: pick date → time modal → cancel → same date → modal reopens
- [ ] Expert: accept pending 1:1 → success UI, no false error
- [ ] BE: `npm test -- acceptIndividualAppointment`
- [ ] FE: `npm test -- StudentExpertBookingPicker`