### PR TITLE
feat: WeChat login, expert follow system, seminar drafts, and rate limiting

### DIFF
--- a/BE/config/authCookie.ts
+++ b/BE/config/authCookie.ts
@@ -1,0 +1,19 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+const defaultMaxAge = () => Number(process.env.COOKIE_EXPIRED_TIME) || 86400000;
+
+const baseAuthCookieOptions = {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure: isProd,
+    path: '/',
+};
+
+const authCookieOptions = (maxAge?: number) => ({
+    ...baseAuthCookieOptions,
+    maxAge: typeof maxAge === 'number' ? maxAge : defaultMaxAge(),
+});
+
+const clearAuthCookieOptions = () => ({ ...baseAuthCookieOptions });
+
+module.exports = { authCookieOptions, clearAuthCookieOptions };

--- a/BE/config/csrf.ts
+++ b/BE/config/csrf.ts
@@ -1,0 +1,26 @@
+const csrf = require("csurf");
+
+const isProd = process.env.NODE_ENV === 'production';
+
+const csrfProtection = csrf({
+    cookie: {
+        key: '_csrf',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: isProd,
+        path: '/',
+    },
+});
+
+const csrfErrorHandler = (err, req, res, next) => {
+    if (err && err.code === 'EBADCSRFTOKEN') {
+        return res.status(403).json({
+            status: 'FAIL',
+            code: 'EBADCSRFTOKEN',
+            error: 'Invalid or missing CSRF token. Please refresh and try again.',
+        });
+    }
+    return next(err);
+};
+
+module.exports = { csrfProtection, csrfErrorHandler };

--- a/BE/controllers/auth.controller.ts
+++ b/BE/controllers/auth.controller.ts
@@ -998,9 +998,66 @@ const updateProfile = async (req: any, res: Response) => {
                     : String(req.body.specialNote);
             updates.specialNote = raw.slice(0, 5000);
         }
+
+        const timeZone = safeParse(req.body.timeZone) || req.body.timeZone;
+        if (timeZone && typeof timeZone === 'string') {
+            updates.timeZone = timeZone;
+        }
+
+        const notificationPreferences =
+            safeParse(req.body.notificationPreferences) || req.body.notificationPreferences;
+        if (notificationPreferences && typeof notificationPreferences === 'object') {
+            const prefKeys = ['email', 'push', 'seminarReminders', 'sessionReminders', 'marketing'];
+            for (const key of prefKeys) {
+                if (typeof notificationPreferences[key] === 'boolean') {
+                    updates[`notificationPreferences.${key}`] = notificationPreferences[key];
+                }
+            }
+        }
+        // synthetic wechat_<id>@wechat.local placeholder email (WeChat returns no email).
+        // Allow them to set a real one here. Only placeholder accounts may change their
+        // email via this endpoint, so normal users can't repoint their account.
+        const { isWeChatPlaceholderEmail } = require('../services/wechatOAuth');
+        const newEmailRaw = safeParse(req.body.email) || req.body.email;
+        if (
+            typeof newEmailRaw === 'string' &&
+            newEmailRaw.trim() &&
+            isWeChatPlaceholderEmail(email) &&
+            !isWeChatPlaceholderEmail(newEmailRaw)
+        ) {
+            const newEmail = newEmailRaw.trim().toLowerCase();
+            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newEmail)) {
+                return res.status(400).json({ status: 'FAIL', error: 'Please enter a valid email address.' });
+            }
+            // v1: block when the email already belongs to another account (no auto-merge).
+            const existing = await User.findOne({ email: { $regex: new RegExp(`^${newEmail}$`, 'i') } });
+            if (existing) {
+                return res.status(409).json({
+                    status: 'FAIL',
+                    error: 'This email is already in use. Please sign in to that account instead.',
+                });
+            }
+            updates.email = newEmail;
+        }
+
         // [User Model] -- add more updating fields based on the user model
         await User.findOneAndUpdate({ email: email }, updates, { new: true })
-        const result = await getFullUserData(email)
+
+        // If the email changed (WeChat bind-email), the email-keyed session token is now
+        // stale — re-issue it so the user stays logged in under the new email.
+        const updatedEmail = updates.email && updates.email !== email ? updates.email : email;
+        if (updatedEmail !== email) {
+            const updatedUser = await User.findOne({ email: updatedEmail });
+            if (updatedUser) {
+                const newToken = await updatedUser.generateAuthToken();
+                res.cookie('accessToken', newToken, {
+                    maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
+                    httpOnly: true,
+                });
+            }
+        }
+
+        const result = await getFullUserData(updatedEmail)
         result.password = null
         result.token = null
         return res.status(200).json({

--- a/BE/controllers/auth.controller.ts
+++ b/BE/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ const PendingUser = require("../models/PendingUser");
 const jwt = require("jsonwebtoken");
 const PendingLogin = require("../models/PendingLogin");
 const PendingPasswordReset = require("../models/PendingPasswordReset");
+const PendingEmailChange = require("../models/PendingEmailChange");
 const Keyword = require("../models/Keyword")
 const Service = require("../models/Service")
 const bcrypt = require("bcryptjs");
@@ -1019,6 +1020,7 @@ const updateProfile = async (req: any, res: Response) => {
         // email via this endpoint, so normal users can't repoint their account.
         const { isWeChatPlaceholderEmail } = require('../services/wechatOAuth');
         const newEmailRaw = safeParse(req.body.email) || req.body.email;
+        let emailVerificationSent = false;
         if (
             typeof newEmailRaw === 'string' &&
             newEmailRaw.trim() &&
@@ -1037,33 +1039,95 @@ const updateProfile = async (req: any, res: Response) => {
                     error: 'This email is already in use. Please sign in to that account instead.',
                 });
             }
-            updates.email = newEmail;
+            const me = await User.findOne({ email: { $eq: email } });
+            if (me) {
+                const confirmCode = uuidv4();
+                await PendingEmailChange.deleteOne({ userId: me._id });
+                await PendingEmailChange.create({
+                    userId: me._id,
+                    currentEmail: email,
+                    newEmail,
+                    confirmCode,
+                });
+                await utils.sendEmailChangeVerification(newEmail, confirmCode);
+                emailVerificationSent = true;
+            }
         }
 
         // [User Model] -- add more updating fields based on the user model
         await User.findOneAndUpdate({ email: email }, updates, { new: true })
 
-        // If the email changed (WeChat bind-email), the email-keyed session token is now
-        // stale — re-issue it so the user stays logged in under the new email.
-        const updatedEmail = updates.email && updates.email !== email ? updates.email : email;
-        const safeUpdatedEmail = typeof updatedEmail === 'string' ? updatedEmail.trim() : null;
-        if (safeUpdatedEmail && safeUpdatedEmail !== email) {
-            const updatedUser = await User.findOne({ email: { $eq: safeUpdatedEmail } });
-            if (updatedUser) {
-                const newToken = await updatedUser.generateAuthToken();
-                res.cookie('accessToken', newToken, {
-                    maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
-                    httpOnly: true,
-                });
-            }
-        }
-
-        const result = await getFullUserData(updatedEmail)
+        const result = await getFullUserData(email)
         result.password = null
         result.token = null
         return res.status(200).json({
             result: result,
+            emailVerificationSent,
         });
+    } catch (err) {
+        console.log(err)
+        return res.status(500).send(HTTP_GENERIC_ERROR);
+    }
+}
+
+const confirmEmailChange = async (req: Request, res: Response) => {
+    try {
+        const { isWeChatPlaceholderEmail } = require('../services/wechatOAuth');
+        const confirmCode = typeof req.body.confirmCode === 'string' ? req.body.confirmCode.trim() : '';
+        if (!confirmCode) {
+            return res.status(200).json({ status: 'FAIL', error: 'This verification link is invalid or has expired.' });
+        }
+
+        const pending = await PendingEmailChange.findOne({ confirmCode: { $eq: confirmCode } });
+        if (!pending) {
+            return res.status(200).json({ status: 'FAIL', error: 'This verification link is invalid or has expired.' });
+        }
+
+        if ((Date.now() - new Date(pending.createdAt).getTime()) >= 24 * 3600 * 1000) {
+            await pending.deleteOne();
+            return res.status(200).json({ status: 'FAIL', error: 'This verification link has expired. Please request a new one.' });
+        }
+
+        const newEmail = String(pending.newEmail).toLowerCase();
+        const existing = await User.findOne({ email: { $eq: newEmail } });
+        if (existing && String(existing._id) !== String(pending.userId)) {
+            await pending.deleteOne();
+            return res.status(409).json({
+                status: 'FAIL',
+                error: 'This email is already in use. Please sign in to that account instead.',
+            });
+        }
+
+        const user = await User.findById(pending.userId);
+        if (!user) {
+            await pending.deleteOne();
+            return res.status(200).json({ status: 'FAIL', error: AUTH_USER_NOT_FOUND });
+        }
+        if (!isWeChatPlaceholderEmail(user.email)) {
+            await pending.deleteOne();
+            return res.status(200).json({ status: 'FAIL', error: 'An email is already set for this account.' });
+        }
+
+        user.email = newEmail;
+        const token = await user.generateAuthToken();
+        await user.save();
+        await pending.deleteOne();
+
+        res.cookie('accessToken', token, {
+            maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
+            httpOnly: true,
+        });
+
+        syncUserToRocketChat({
+            email: user.email,
+            username: user.username,
+            name: user.username,
+        }).catch(err => console.error('RC sync failed (email-change):', err.message));
+
+        const result = await getFullUserData(newEmail);
+        result.password = null;
+        result.token = null;
+        return res.status(200).json({ status: 'SUCCESS', userDetails: result });
     } catch (err) {
         console.log(err)
         return res.status(500).send(HTTP_GENERIC_ERROR);
@@ -1404,6 +1468,7 @@ module.exports = {
     passwordResetRequest,
     verifyPasswordResetOTP,
     confirmPasswordResetByCode,
+    confirmEmailChange,
     updateResume,
     uploadChatFile,
     healthCheck,

--- a/BE/controllers/auth.controller.ts
+++ b/BE/controllers/auth.controller.ts
@@ -5,6 +5,7 @@ const jwt = require("jsonwebtoken");
 const PendingLogin = require("../models/PendingLogin");
 const PendingPasswordReset = require("../models/PendingPasswordReset");
 const PendingEmailChange = require("../models/PendingEmailChange");
+const { authCookieOptions, clearAuthCookieOptions } = require("../config/authCookie");
 const Keyword = require("../models/Keyword")
 const Service = require("../models/Service")
 const bcrypt = require("bcryptjs");
@@ -464,11 +465,8 @@ const verifyRegistration = async (req: Request, res: Response) => {
         
         user.token = null;
         user.password = null;
-        
-        res.cookie('accessToken', token, {
-            maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
-            httpOnly: true
-        });
+
+        res.cookie('accessToken', token, authCookieOptions());
 
 
         res.status(200).json({
@@ -500,10 +498,7 @@ const checkVerificationStatus = async (req: Request, res: Response) => {
             user.token = null;
             user.password = null;
 
-            res.cookie('accessToken', token, {
-                maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
-                httpOnly: true
-            });
+            res.cookie('accessToken', token, authCookieOptions());
 
             return res.status(200).json({ status: 'VERIFIED', userDetails: user });
         }
@@ -647,7 +642,7 @@ const confirmLoginByCode = async (req: Request, res: Response) => {
         const token = await user.generateAuthToken()
         user.token = null
         user.password = null
-        res.cookie('accessToken', token, { maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000, httpOnly: true })
+        res.cookie('accessToken', token, authCookieOptions())
 
         // Ensure user exists in Rocket.Chat (fire-and-forget)
         syncUserToRocketChat({
@@ -1113,10 +1108,7 @@ const confirmEmailChange = async (req: Request, res: Response) => {
         await user.save();
         await pending.deleteOne();
 
-        res.cookie('accessToken', token, {
-            maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
-            httpOnly: true,
-        });
+        res.cookie('accessToken', token, authCookieOptions());
 
         syncUserToRocketChat({
             email: user.email,
@@ -1401,10 +1393,7 @@ const sendEmailToAdmin = async (req: Request, res: Response) => {
 
 const logout = async (req: Request, res: Response) => {
     try {
-        res.clearCookie('accessToken', {
-            httpOnly: true,
-            path: '/'
-        });
+        res.clearCookie('accessToken', clearAuthCookieOptions());
         return res.status(200).json({
             status: "SUCCESS"
         });

--- a/BE/controllers/auth.controller.ts
+++ b/BE/controllers/auth.controller.ts
@@ -547,7 +547,7 @@ const login = async (req: Request, res: Response) => {
         // const code = randomize('0', 6)
         const code = "123456"
 
-        let loginRequest = await PendingLogin.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } })
+        let loginRequest = await PendingLogin.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } })
         if (!loginRequest) {
             loginRequest = new PendingLogin({
                 email,
@@ -603,7 +603,7 @@ const confirmLoginByCode = async (req: Request, res: Response) => {
     try {
 
         const { email, password, code } = req.body;
-        const loginRequest = await PendingLogin.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } })
+        const loginRequest = await PendingLogin.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } })
         if (!loginRequest) {
             return res.status(200).json({ status: 'FAIL', error: AUTH_LOGIN_REQUEST_EXPIRED });
         }
@@ -676,7 +676,7 @@ const passwordResetRequest = async (req: Request, res: Response) => {
     try {
         const { email, password } = req.body
 
-        const user = await User.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } }).select('+password')
+        const user = await User.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } }).select('+password')
 
         if (!user) {
             return res.status(200).json({ status: 'FAIL', error: AUTH_EMAIL_NOT_FOUND });
@@ -696,7 +696,7 @@ const passwordResetRequest = async (req: Request, res: Response) => {
             ? await bcrypt.hash(String(password), 10)
             : undefined;
 
-        const pwdRequest = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } })
+        const pwdRequest = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } })
         if (!pwdRequest) {
             const newRequest = new PendingPasswordReset({
                 email,
@@ -748,7 +748,7 @@ const verifyPasswordResetOTP = async (req: Request, res: Response) => {
     try {
         const { email, code } = req.body;
 
-        const pwdRequest = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } });
+        const pwdRequest = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } });
         if (!pwdRequest) {
             return res.status(200).json({ status: 'FAIL', error: AUTH_PASSWORD_RESET_EXPIRED });
         }
@@ -784,7 +784,7 @@ const confirmPasswordResetByCode = async (req: Request, res: Response) => {
             return res.status(200).json({ status: 'FAIL', error: AUTH_PASSWORD_WEAK });
         }
 
-        const request = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${email}$`, 'i') } })
+        const request = await PendingPasswordReset.findOne({ email: { $regex: new RegExp(`^${utils.escapeRegExp(email)}$`, 'i') } })
         if (!request) {
             return res.status(200).json({ status: 'FAIL', error: AUTH_PASSWORD_RESET_EXPIRED });
         }
@@ -1026,11 +1026,11 @@ const updateProfile = async (req: any, res: Response) => {
             !isWeChatPlaceholderEmail(newEmailRaw)
         ) {
             const newEmail = newEmailRaw.trim().toLowerCase();
-            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newEmail)) {
+            if (!/^[^\s@.]+(\.[^\s@.]+)*@[^\s@.]+(\.[^\s@.]+)+$/.test(newEmail)) {
                 return res.status(400).json({ status: 'FAIL', error: 'Please enter a valid email address.' });
             }
             // v1: block when the email already belongs to another account (no auto-merge).
-            const existing = await User.findOne({ email: { $regex: new RegExp(`^${newEmail}$`, 'i') } });
+            const existing = await User.findOne({ email: { $eq: newEmail } });
             if (existing) {
                 return res.status(409).json({
                     status: 'FAIL',
@@ -1046,8 +1046,9 @@ const updateProfile = async (req: any, res: Response) => {
         // If the email changed (WeChat bind-email), the email-keyed session token is now
         // stale — re-issue it so the user stays logged in under the new email.
         const updatedEmail = updates.email && updates.email !== email ? updates.email : email;
-        if (updatedEmail !== email) {
-            const updatedUser = await User.findOne({ email: updatedEmail });
+        const safeUpdatedEmail = typeof updatedEmail === 'string' ? updatedEmail.trim() : null;
+        if (safeUpdatedEmail && safeUpdatedEmail !== email) {
+            const updatedUser = await User.findOne({ email: { $eq: safeUpdatedEmail } });
             if (updatedUser) {
                 const newToken = await updatedUser.generateAuthToken();
                 res.cookie('accessToken', newToken, {

--- a/BE/controllers/customer.controller.ts
+++ b/BE/controllers/customer.controller.ts
@@ -7,6 +7,20 @@ const PaymentHistory = require("../models/PaymentHistory");
 // Escape user-supplied text so it can be used safely inside a regex (prevents ReDoS / injection).
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+//  - followerCount: how many customers follow the expert
+//  - isFollowing:   whether the requesting customer already follows them
+const withFollowInfo = (expert: any, myFollowingIds: Set<string>) => {
+    const plain = typeof expert.toObject === 'function' ? expert.toObject() : expert;
+    return {
+        ...plain,
+        followerCount: Array.isArray(plain.followers) ? plain.followers.length : 0,
+        isFollowing: myFollowingIds.has(String(plain._id)),
+    };
+};
+
+const followingIdSet = (reqUser: any): Set<string> =>
+    new Set((reqUser?.following || []).map((id: any) => String(id)));
+
 const filterExperts = async (req: any, res: Response) => {
     try {
         const { _id, username, keywords, services, sortBy } = req.body
@@ -65,6 +79,9 @@ const filterExperts = async (req: any, res: Response) => {
             case "Price in DESC":
                 query.sort({ price: -1 })
                 break;
+            case "Recently joined":
+                query.sort({ createdAt: -1 })
+                break;
             default:
                 break;
         }
@@ -85,9 +102,10 @@ const filterExperts = async (req: any, res: Response) => {
                 ]
             }])
         const experts = await query.exec();
+        const myFollowing = followingIdSet(req.user);
 
         return res.status(200).json({
-            result: experts
+            result: experts.map((e: any) => withFollowInfo(e, myFollowing))
         })
     } catch (err) {
         console.log(err)
@@ -102,6 +120,7 @@ const filterSeminars = async (req, res) => {
 
         let query = GroupChat.find({
             type: 'seminar',
+            status: { $ne: 'draft' }, // never surface an expert's unfinished drafts to students
             $or: [
                 {
                     start: { $gt: new Date() },
@@ -181,21 +200,71 @@ const filterSeminars = async (req, res) => {
 
 const getExpertById = async (req, res) => {
     try {
-        console.log("inside getExpertById")
         const { id } = req.params
         const query = await User.findById(id).populate(["keywords","services","events","groupChats"
         ,{
             path: "pendingGroupChats",
-            populate: ["groupChatId"],  
+            populate: ["groupChatId"],
         },
         ])
 
-        console.log("inside getExpertById", query)
+        if (!query) {
+            return res.status(404).send("Expert not found");
+        }
+
         return res.status(200).json({
-            result: query
+            result: withFollowInfo(query, followingIdSet(req.user))
         })
     }
     catch (err) {
+        console.log(err)
+        return res.status(500).send(err.message);
+    }
+}
+
+const followExpert = async (req: any, res: Response) => {
+    try {
+        const { userId } = req.user
+        const { expertId } = req.params
+
+        if (String(userId) === String(expertId)) {
+            return res.status(400).send("You cannot follow yourself");
+        }
+
+        const expert = await User.findOne({ _id: expertId, role: 'expert' });
+        if (!expert) {
+            return res.status(404).send("Expert not found");
+        }
+
+        await User.updateOne({ _id: userId }, { $addToSet: { following: expertId } });
+        await User.updateOne({ _id: expertId }, { $addToSet: { followers: userId } });
+
+        const updated = await User.findById(expertId).select('followers');
+        return res.status(200).json({
+            following: true,
+            followerCount: updated?.followers?.length ?? 0,
+        });
+    } catch (err: any) {
+        console.log(err)
+        return res.status(500).send(err.message);
+    }
+}
+
+// Unfollow an expert: remove the link from both sides.
+const unfollowExpert = async (req: any, res: Response) => {
+    try {
+        const { userId } = req.user
+        const { expertId } = req.params
+
+        await User.updateOne({ _id: userId }, { $pull: { following: expertId } });
+        await User.updateOne({ _id: expertId }, { $pull: { followers: userId } });
+
+        const updated = await User.findById(expertId).select('followers');
+        return res.status(200).json({
+            following: false,
+            followerCount: updated?.followers?.length ?? 0,
+        });
+    } catch (err: any) {
         console.log(err)
         return res.status(500).send(err.message);
     }
@@ -228,5 +297,7 @@ module.exports = {
     filterExperts,
     filterSeminars,
     getExpertById,
+    followExpert,
+    unfollowExpert,
     getMyPaymentHistory,
 }

--- a/BE/controllers/groupChat.controller.ts
+++ b/BE/controllers/groupChat.controller.ts
@@ -675,7 +675,7 @@ const createGroupChatByUser = async (req, res) => {
 const createGroupChat = async (req, res) => {
     try {
         const { userId } = req.user;
-        const { name, description, services, keywords, start, end, duration, price, type, status, customerId } = req.body;
+        const { name, description, image, services, keywords, start, end, duration, price, type, status, customerId } = req.body;
 
         if (checkTitleNameInvalid('Name', name)) {
             throw new Error(checkTitleNameInvalid('Name', name))
@@ -688,6 +688,7 @@ const createGroupChat = async (req, res) => {
         const chat = await GroupChat.create({
             name: name,
             description: description,
+            image: image,
             services: _services,
             keywords: _keywords,
             start: start,
@@ -916,7 +917,7 @@ const joinGroupChat = async (req, res) => {
 const updateGroupChat = async (req, res) => {
     try {
         const { userId } = req.user;
-        const { groupId, name, description, services, keywords, start, end, duration, price, totalTimeSpent, type } = req.body;
+        const { groupId, name, description, image, services, keywords, start, end, duration, price, totalTimeSpent, type, status } = req.body;
 
         if (!groupId) {
             throw new Error("Group ID is required");
@@ -938,6 +939,11 @@ const updateGroupChat = async (req, res) => {
         const updateFields: Record<string, any> = {};
         if (name !== undefined) updateFields.name = name;
         if (description !== undefined) updateFields.description = description;
+        if (image !== undefined) updateFields.image = image;
+        // Allow flipping a draft to a published seminar (or saving back as draft).
+        if (status !== undefined && ['draft', 'active', 'pending'].includes(status)) {
+            updateFields.status = status;
+        }
         if (services !== undefined) updateFields.services = await resolveServiceIds(services);
         if (keywords !== undefined) updateFields.keywords = await resolveKeywordIds(keywords);
         if (start !== undefined) updateFields.start = start;

--- a/BE/controllers/groupChat.controller.ts
+++ b/BE/controllers/groupChat.controller.ts
@@ -709,7 +709,7 @@ const createGroupChat = async (req, res) => {
         // [REMOVED] updateUsersGroupChatList(userId.toString());
 
         if (type === 'individual' && customerId) {
-            const customer = await User.findById(customerId);
+            const customer = await User.findById(String(customerId));
             if (!customer) {
                 throw new Error("Customer not found");
             }
@@ -732,7 +732,7 @@ const createGroupChat = async (req, res) => {
     } catch (err) {
         return res
             .status(500)
-            .send(err.message);
+            .send(safeErrorMessage(err));
     }
 };
 
@@ -923,7 +923,7 @@ const updateGroupChat = async (req, res) => {
             throw new Error("Group ID is required");
         }
 
-        const groupChat = await GroupChat.findById(groupId);
+        const groupChat = await GroupChat.findById(String(groupId));
 
         if (!groupChat) {
             throw new Error("Group chat not found");
@@ -958,7 +958,7 @@ const updateGroupChat = async (req, res) => {
         }
 
         // Update group chat with only provided fields
-        await GroupChat.findByIdAndUpdate(groupId, updateFields, { new: true });
+        await GroupChat.findByIdAndUpdate(String(groupId), updateFields, { new: true });
 
         // [REMOVED] updateUsersGroupChatList(userId.toString());
 
@@ -970,7 +970,7 @@ const updateGroupChat = async (req, res) => {
             result: userDetails,
         });
     } catch (err) {
-        return res.status(500).send(err.message);
+        return res.status(500).send(safeErrorMessage(err));
     }
 };
 

--- a/BE/controllers/groupChat.controller.ts
+++ b/BE/controllers/groupChat.controller.ts
@@ -935,24 +935,25 @@ const updateGroupChat = async (req, res) => {
             return res.status(403).send("Forbidden");
         }
 
-        // Construct dynamic update object. Coerce every user-supplied value to its
-        // expected primitive so a query object (e.g. { $gt: '' }) can't be injected.
+        // Construct dynamic update object. Each field is accepted only when it is a
+        // primitive (string/number) via an inline typeof check, so a query object
+        // (e.g. { $gt: '' }) can never be injected into findByIdAndUpdate.
         const updateFields: Record<string, any> = {};
-        if (name !== undefined) updateFields.name = String(name);
-        if (description !== undefined) updateFields.description = String(description);
-        if (image !== undefined) updateFields.image = String(image);
+        if (typeof name === 'string') updateFields.name = name;
+        if (typeof description === 'string') updateFields.description = description;
+        if (typeof image === 'string') updateFields.image = image;
         // Allow flipping a draft to a published seminar (or saving back as draft).
-        if (status !== undefined && ['draft', 'active', 'pending'].includes(status)) {
+        if (typeof status === 'string' && ['draft', 'active', 'pending'].includes(status)) {
             updateFields.status = status;
         }
         if (services !== undefined) updateFields.services = await resolveServiceIds(services);
         if (keywords !== undefined) updateFields.keywords = await resolveKeywordIds(keywords);
-        if (start !== undefined) updateFields.start = new Date(start);
-        if (end !== undefined) updateFields.end = new Date(end);
-        if (duration !== undefined) updateFields.duration = Number(duration);
-        if (price !== undefined) updateFields.price = Number(price);
-        if (type !== undefined && normalizeId(groupChat.admin) === String(userId)) updateFields.type = String(type);
-        if (totalTimeSpent !== undefined) {
+        if (typeof start === 'string' || typeof start === 'number') updateFields.start = new Date(start);
+        if (typeof end === 'string' || typeof end === 'number') updateFields.end = new Date(end);
+        if (typeof duration === 'string' || typeof duration === 'number') updateFields.duration = Number(duration);
+        if (typeof price === 'string' || typeof price === 'number') updateFields.price = Number(price);
+        if (typeof type === 'string' && normalizeId(groupChat.admin) === String(userId)) updateFields.type = type;
+        if (typeof totalTimeSpent === 'string' || typeof totalTimeSpent === 'number') {
             const existingTotalTimeSpent = groupChat.totalTimeSpent || 0;
             updateFields.totalTimeSpent = existingTotalTimeSpent + Number(totalTimeSpent);
         }

--- a/BE/controllers/groupChat.controller.ts
+++ b/BE/controllers/groupChat.controller.ts
@@ -935,26 +935,26 @@ const updateGroupChat = async (req, res) => {
             return res.status(403).send("Forbidden");
         }
 
-        // Construct dynamic update object
+        // Construct dynamic update object. Coerce every user-supplied value to its
+        // expected primitive so a query object (e.g. { $gt: '' }) can't be injected.
         const updateFields: Record<string, any> = {};
-        if (name !== undefined) updateFields.name = name;
-        if (description !== undefined) updateFields.description = description;
-        if (image !== undefined) updateFields.image = image;
+        if (name !== undefined) updateFields.name = String(name);
+        if (description !== undefined) updateFields.description = String(description);
+        if (image !== undefined) updateFields.image = String(image);
         // Allow flipping a draft to a published seminar (or saving back as draft).
         if (status !== undefined && ['draft', 'active', 'pending'].includes(status)) {
             updateFields.status = status;
         }
         if (services !== undefined) updateFields.services = await resolveServiceIds(services);
         if (keywords !== undefined) updateFields.keywords = await resolveKeywordIds(keywords);
-        if (start !== undefined) updateFields.start = start;
-        if (end !== undefined) updateFields.end = end;
-        if (duration !== undefined) updateFields.duration = duration;
-        if (price !== undefined) updateFields.price = price;
-        if (type !== undefined && normalizeId(groupChat.admin) === String(userId)) updateFields.type = type;
+        if (start !== undefined) updateFields.start = new Date(start);
+        if (end !== undefined) updateFields.end = new Date(end);
+        if (duration !== undefined) updateFields.duration = Number(duration);
+        if (price !== undefined) updateFields.price = Number(price);
+        if (type !== undefined && normalizeId(groupChat.admin) === String(userId)) updateFields.type = String(type);
         if (totalTimeSpent !== undefined) {
-            //updateFields.totalTimeSpend = totalTimeSpent;
             const existingTotalTimeSpent = groupChat.totalTimeSpent || 0;
-            updateFields.totalTimeSpent = existingTotalTimeSpent + totalTimeSpent;
+            updateFields.totalTimeSpent = existingTotalTimeSpent + Number(totalTimeSpent);
         }
 
         // Update group chat with only provided fields

--- a/BE/middlewares/rateLimit.ts
+++ b/BE/middlewares/rateLimit.ts
@@ -1,0 +1,35 @@
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+
+// Trust the per-route auth middleware to attach the user; fall back to IP.
+// ipKeyGenerator normalizes IPv6 so clients can't bypass limits by rotating addresses.
+const keyByUserOrIp = (req: any): string => {
+    const userId = req?.user?._id || req?.user?.id || req?.userId;
+    return userId ? `u:${userId}` : `ip:${ipKeyGenerator(req.ip)}`;
+};
+
+const RATE_LIMIT_DISABLED = process.env.RATE_LIMIT_DISABLED === 'true';
+
+const message = { success: false, message: 'Too many requests, please try again later.' };
+
+export const apiLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 300,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: keyByUserOrIp,
+    skip: () => RATE_LIMIT_DISABLED,
+    message,
+});
+
+
+export const sensitiveLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: keyByUserOrIp,
+    skip: () => RATE_LIMIT_DISABLED,
+    message,
+});
+
+module.exports = { apiLimiter, sensitiveLimiter };

--- a/BE/middlewares/requireAuth.ts
+++ b/BE/middlewares/requireAuth.ts
@@ -4,9 +4,11 @@ const UserModel = require('../models/User')
 
 const config = process.env;
 
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const getFullUserData = async (email) => {
     return await UserModel.findOne({
-        email: { $regex: new RegExp(`^${email}$`, 'i') }
+        email: { $regex: new RegExp(`^${escapeRegExp(email)}$`, 'i') }
     })
         .select("+password")
         .populate([

--- a/BE/middlewares/requireAuth.ts
+++ b/BE/middlewares/requireAuth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 const jwt = require("jsonwebtoken");
 const UserModel = require('../models/User')
+const { authCookieOptions } = require('../config/authCookie')
 
 const config = process.env;
 
@@ -125,7 +126,7 @@ const requireAuth = (restrictUnderReview = false) => async (req, res, next) => {
             throw new Error("server side cookie has been expired.");
 
         const newToken = await user.generateAuthToken()
-        res.cookie('accessToken', newToken, { maxAge: process.env.COOKIE_EXPIRED_TIME, httpOnly: true });
+        res.cookie('accessToken', newToken, authCookieOptions());
 
         req.user = {
             userId: user._id.toString(),
@@ -183,7 +184,7 @@ const customerAuth = (restrictUnderReview = false) => async (req, res, next) => 
             throw new Error("server side cookie has been expired.");
 
         const newToken = await user.generateAuthToken()
-        res.cookie('accessToken', newToken, { maxAge: process.env.COOKIE_EXPIRED_TIME, httpOnly: true });
+        res.cookie('accessToken', newToken, authCookieOptions());
         req.user = {
             userId: user._id.toString(),
             ...user._doc,
@@ -240,7 +241,7 @@ const expertAuth = (restrictUnderReview = false) => async (req, res, next) => {
             throw new Error("server side cookie has been expired.");
 
         const newToken = await user.generateAuthToken()
-        res.cookie('accessToken', newToken, { maxAge: process.env.COOKIE_EXPIRED_TIME, httpOnly: true });
+        res.cookie('accessToken', newToken, authCookieOptions());
         req.user = {
             userId: user._id.toString(),
             ...user._doc,
@@ -289,7 +290,7 @@ const adminAuth = async (req, res, next) => {
             throw new Error("server side cookie has been expired.");
 
         const newToken = await user.generateAuthToken()
-        res.cookie('accessToken', newToken, { maxAge: process.env.COOKIE_EXPIRED_TIME, httpOnly: true });
+        res.cookie('accessToken', newToken, authCookieOptions());
         req.user = {
             userId: user._id.toString(),
             ...user._doc,

--- a/BE/models/GroupChat.ts
+++ b/BE/models/GroupChat.ts
@@ -10,6 +10,7 @@ const groupChatSchema = new mongoose.Schema(
         description: {
             type: String,
         },
+        image: { type: String },
         keywords: [{ type: mongoose.Schema.Types.ObjectId, ref: "Keyword" }],
         services: [{ type: mongoose.Schema.Types.ObjectId, ref: "Service" }],
         start: { type: Date },
@@ -22,7 +23,7 @@ const groupChatSchema = new mongoose.Schema(
             enum: ["seminar", "individual", "community"],
             default: "seminar",
         },
-        status: {type: String, enum: ["pending", "active", "cancelled"], default: 'pending'},
+        status: {type: String, enum: ["draft", "pending", "active", "cancelled"], default: 'pending'},
         createdBy: {
             type: mongoose.Schema.Types.ObjectId,
             ref: "User",

--- a/BE/models/PendingEmailChange.ts
+++ b/BE/models/PendingEmailChange.ts
@@ -1,0 +1,22 @@
+const mongoose = require("mongoose");
+
+const pendingEmailChangeSchema = new mongoose.Schema(
+    {
+        userId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+            unique: true,
+        },
+        currentEmail: { type: String, required: true },
+        newEmail: { type: String, required: true },
+        confirmCode: { type: String, required: true },
+        failedAttempts: { type: Number, default: 0 },
+        lockUntil: { type: Date },
+    },
+    { timestamps: true }
+);
+
+pendingEmailChangeSchema.index({ createdAt: 1 }, { expireAfterSeconds: 86400 });
+
+module.exports = mongoose.model("PendingEmailChange", pendingEmailChangeSchema);

--- a/BE/models/User.ts
+++ b/BE/models/User.ts
@@ -18,6 +18,8 @@ const userSchema = new mongoose.Schema(
         image: { type: String },
         role: { type: String, required: true, default: 'customer' },
         friends: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
+        following: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
+        followers: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
         /** 1:1 DM threads (Rocket.Chat IM); not used for community/group sessions. */
         directConversations: [{ type: mongoose.Schema.Types.ObjectId, ref: "Conversation" }],
         groupChats: [{ type: mongoose.Schema.Types.ObjectId, ref: "GroupChat" }],
@@ -31,13 +33,22 @@ const userSchema = new mongoose.Schema(
         feedbacks: [{ type: mongoose.Schema.Types.Mixed }],
         status: { type: String, default: 'review' },
         timeZone: { type: String, default: 'UTC' },
+
+        notificationPreferences: {
+            email: { type: Boolean, default: true },
+            push: { type: Boolean, default: true },
+            seminarReminders: { type: Boolean, default: true },
+            sessionReminders: { type: Boolean, default: true },
+            marketing: { type: Boolean, default: false },
+        },
         isActive: { type: Boolean, default: true },
         isAdHocCustomer: { type: Boolean, default: false },
         token: { type: String, select: false },
         password: { type: String, select: false },
 
         // OAUTH ---------------
-        oauthProvider: { type: String }, // 'google' | 'facebook' | 'twitter'
+        oauthProvider: { type: String }, // 'google' | 'wechat' | 'facebook' | 'twitter'
+        // For WeChat (no email returned), oauthId holds unionid (preferred) or openid.
         oauthId: { type: String },
 
         // EXPERT -------------

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -16,6 +16,7 @@
         "buffer-equal-constant-time": "^1.0.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
+        "csurf": "^1.11.0",
         "dotenv": "^16.0.0",
         "env-cmd": "^10.1.0",
         "express": "^4.17.3",
@@ -49,8 +50,10 @@
         "@types/passport-facebook": "^3.0.4",
         "@types/passport-google-oauth20": "^2.0.17",
         "@types/passport-twitter": "^1.0.40",
+        "@types/supertest": "^7.2.0",
         "c8": "^10.1.3",
         "nodemon": "^2.0.15",
+        "supertest": "^7.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }
@@ -1436,6 +1439,29 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2266,6 +2292,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -2335,6 +2368,13 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2474,6 +2514,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -2552,6 +2616,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -2924,6 +2995,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3002,6 +3083,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3037,6 +3125,94 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/debug": {
@@ -3083,6 +3259,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -3382,6 +3569,13 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
@@ -3499,6 +3693,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4514,6 +4726,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4876,6 +5098,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5268,6 +5496,90 @@
       ],
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5403,6 +5715,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -5683,6 +6004,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xmldom": {
       "version": "0.1.31",

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -20,6 +20,7 @@
         "env-cmd": "^10.1.0",
         "express": "^4.17.3",
         "express-joi-validation": "^5.0.1",
+        "express-rate-limit": "^8.5.2",
         "express-session": "^1.19.0",
         "form-data": "^4.0.1",
         "joi": "^17.6.0",
@@ -3334,6 +3335,24 @@
         "joi": "17"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
@@ -3757,6 +3776,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/BE/package.json
+++ b/BE/package.json
@@ -24,6 +24,7 @@
     "env-cmd": "^10.1.0",
     "express": "^4.17.3",
     "express-joi-validation": "^5.0.1",
+    "express-rate-limit": "^8.5.2",
     "express-session": "^1.19.0",
     "form-data": "^4.0.1",
     "joi": "^17.6.0",

--- a/BE/package.json
+++ b/BE/package.json
@@ -20,6 +20,7 @@
     "buffer-equal-constant-time": "^1.0.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "csurf": "^1.11.0",
     "dotenv": "^16.0.0",
     "env-cmd": "^10.1.0",
     "express": "^4.17.3",
@@ -53,8 +54,10 @@
     "@types/passport-facebook": "^3.0.4",
     "@types/passport-google-oauth20": "^2.0.17",
     "@types/passport-twitter": "^1.0.40",
+    "@types/supertest": "^7.2.0",
     "c8": "^10.1.3",
     "nodemon": "^2.0.15",
+    "supertest": "^7.2.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/BE/routes/adminRoutes.ts
+++ b/BE/routes/adminRoutes.ts
@@ -1,5 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const { apiLimiter } = require("../middlewares/rateLimit");
+router.use(apiLimiter);
 const {
     adminAuth
 } = require("../middlewares/requireAuth");

--- a/BE/routes/authRoutes.ts
+++ b/BE/routes/authRoutes.ts
@@ -29,6 +29,7 @@ const {
 
 } = require("../controllers/auth.controller");
 const { requireAuth } = require("../middlewares/requireAuth");
+const { apiLimiter, sensitiveLimiter } = require("../middlewares/rateLimit");
 const {
     validateLoginSchema,
     validateRegisterSchema
@@ -49,7 +50,10 @@ const {
     getChatBotAnswer
 } = require('../controllers/chatBotQA.controller')
 
-router.post("/register", uploadsGeneral, register);
+// Baseline rate limiting for every auth route below.
+router.use(apiLimiter);
+
+router.post("/register", sensitiveLimiter, uploadsGeneral, register);
 router.post("/updateResume", uploadsGeneral, updateResume);
 router.post("/uploadChatFile", (req: any, res: any, next: any) => {
     uploadsChatFile(req, res, (err: any) => {
@@ -65,12 +69,12 @@ router.post("/uploadChatFile", (req: any, res: any, next: any) => {
 router.post("/resendConfirmEmail", resendConfirmEmail);
 router.post("/verifyRegistration", verifyRegistration);
 router.get("/checkVerification", checkVerificationStatus);
-router.post("/login", validateLoginSchema, login);
+router.post("/login", sensitiveLimiter, validateLoginSchema, login);
 router.post("/logout", logout);
-router.post("/confirmLoginByCode", confirmLoginByCode);
-router.post("/passwordResetRequest", passwordResetRequest);
-router.post("/verifyPasswordResetOTP", verifyPasswordResetOTP);
-router.post("/confirmPasswordResetByCode", confirmPasswordResetByCode);
+router.post("/confirmLoginByCode", sensitiveLimiter, confirmLoginByCode);
+router.post("/passwordResetRequest", sensitiveLimiter, passwordResetRequest);
+router.post("/verifyPasswordResetOTP", sensitiveLimiter, verifyPasswordResetOTP);
+router.post("/confirmPasswordResetByCode", sensitiveLimiter, confirmPasswordResetByCode);
 router.get("/getKeywordsAndServices", getKeywordsAndServices);
 router.post("/updateMissedChats", requireAuth(false), updateMissedChats);
 router.post("/updateProfile", requireAuth(false), updateProfile);
@@ -81,9 +85,9 @@ router.get("/me", requireAuth(false), getMe);
 router.get("/getMyEvents", requireAuth(false), getMyEvents);
 router.post("/submit", uploadsGeneral, handleSubmit)
 router.post("/leaveFeedback", requireAuth(false), leaveFeedback)
-router.post("/stripePay", requireAuth(true), stripePay)
-router.post("/createStripePaymentIntent", requireAuth(true), createStripePaymentIntent)
-router.post("/getStripeMode", requireAuth(true), getStripeMode)
+router.post("/stripePay", sensitiveLimiter, requireAuth(true), stripePay)
+router.post("/createStripePaymentIntent", sensitiveLimiter, requireAuth(true), createStripePaymentIntent)
+router.post("/getStripeMode", sensitiveLimiter, requireAuth(true), getStripeMode)
 router.get("/healthCheck", healthCheck)
 router.get("/getTimezone",getTimeZone)
 router.post("/contact-form", submitContactForm)
@@ -222,6 +226,35 @@ router.get('/google', (req: any, res: any, next: any) => {
     passport.authenticate('google', { scope: ['profile', 'email'], state, session: false })(req, res, next);
 });
 router.get('/google/callback', passport.authenticate('google', { failureRedirect: '/login?error=google_failed', session: false }), oauthCallback);
+
+// WeChat (website QR / web login) — not a passport strategy, plain server-side HTTP.
+const { buildWeChatAuthUrl, exchangeCodeForUser, findOrCreateWeChatUser } = require('../services/wechatOAuth');
+
+router.get('/wechat', (req: any, res: any) => {
+    const role = req.query.role || 'login';
+    const redirectPath = String(req.query.redirect || '').trim();
+    const timezone = String(req.query.timezone || '').trim();
+    const state = encodeURIComponent(JSON.stringify({
+        role,
+        redirect: redirectPath.startsWith('/') ? redirectPath : '',
+        timezone,
+    }));
+    res.redirect(buildWeChatAuthUrl(state));
+});
+
+router.get('/wechat/callback', async (req: any, res: any) => {
+    try {
+        if (req.query.errcode || !req.query.code) {
+            return res.redirect(`${process.env.FE_URL}/login?error=wechat_failed`);
+        }
+        const profile = await exchangeCodeForUser(String(req.query.code));
+        req.user = await findOrCreateWeChatUser(profile); // { user, isNew }
+        return oauthCallback(req, res); // reuse the shared OAuth callback (state, role, token, redirect)
+    } catch (err) {
+        console.error('[WeChat OAuth Callback Error]', err);
+        return res.redirect(`${process.env.FE_URL}/login?error=wechat_failed`);
+    }
+});
 
 
 

--- a/BE/routes/authRoutes.ts
+++ b/BE/routes/authRoutes.ts
@@ -30,6 +30,7 @@ const {
 
 } = require("../controllers/auth.controller");
 const { requireAuth } = require("../middlewares/requireAuth");
+const { authCookieOptions } = require("../config/authCookie");
 const { apiLimiter, sensitiveLimiter } = require("../middlewares/rateLimit");
 const {
     validateLoginSchema,
@@ -77,6 +78,7 @@ router.post("/passwordResetRequest", sensitiveLimiter, passwordResetRequest);
 router.post("/verifyPasswordResetOTP", sensitiveLimiter, verifyPasswordResetOTP);
 router.post("/confirmPasswordResetByCode", sensitiveLimiter, confirmPasswordResetByCode);
 router.post("/confirmEmailChange", sensitiveLimiter, confirmEmailChange);
+router.get("/csrf-token", (req: any, res: any) => res.status(200).json({ csrfToken: req.csrfToken() }));
 router.get("/getKeywordsAndServices", getKeywordsAndServices);
 router.post("/updateMissedChats", requireAuth(false), updateMissedChats);
 router.post("/updateProfile", requireAuth(false), updateProfile);
@@ -170,10 +172,7 @@ const oauthCallback = async (req: any, res: any) => {
         user.token = token;
         await user.save();
         
-        res.cookie('accessToken', token, {
-            maxAge: Number(process.env.COOKIE_EXPIRED_TIME) || 86400000,
-            httpOnly: true
-        });
+        res.cookie('accessToken', token, authCookieOptions());
         
         // Sync user to Rocket.Chat (fire-and-forget)
         syncUserToRocketChat({

--- a/BE/routes/authRoutes.ts
+++ b/BE/routes/authRoutes.ts
@@ -20,6 +20,7 @@ const {
     passwordResetRequest,
     verifyPasswordResetOTP,
     confirmPasswordResetByCode,
+    confirmEmailChange,
     updateResume,
     uploadChatFile,
     healthCheck,
@@ -75,6 +76,7 @@ router.post("/confirmLoginByCode", sensitiveLimiter, confirmLoginByCode);
 router.post("/passwordResetRequest", sensitiveLimiter, passwordResetRequest);
 router.post("/verifyPasswordResetOTP", sensitiveLimiter, verifyPasswordResetOTP);
 router.post("/confirmPasswordResetByCode", sensitiveLimiter, confirmPasswordResetByCode);
+router.post("/confirmEmailChange", sensitiveLimiter, confirmEmailChange);
 router.get("/getKeywordsAndServices", getKeywordsAndServices);
 router.post("/updateMissedChats", requireAuth(false), updateMissedChats);
 router.post("/updateProfile", requireAuth(false), updateProfile);

--- a/BE/routes/authRoutes.ts
+++ b/BE/routes/authRoutes.ts
@@ -85,9 +85,9 @@ router.get("/me", requireAuth(false), getMe);
 router.get("/getMyEvents", requireAuth(false), getMyEvents);
 router.post("/submit", uploadsGeneral, handleSubmit)
 router.post("/leaveFeedback", requireAuth(false), leaveFeedback)
-router.post("/stripePay", sensitiveLimiter, requireAuth(true), stripePay)
-router.post("/createStripePaymentIntent", sensitiveLimiter, requireAuth(true), createStripePaymentIntent)
-router.post("/getStripeMode", sensitiveLimiter, requireAuth(true), getStripeMode)
+router.post("/stripePay", requireAuth(true), sensitiveLimiter, stripePay)
+router.post("/createStripePaymentIntent", requireAuth(true), sensitiveLimiter, createStripePaymentIntent)
+router.post("/getStripeMode", requireAuth(true), sensitiveLimiter, getStripeMode)
 router.get("/healthCheck", healthCheck)
 router.get("/getTimezone",getTimeZone)
 router.post("/contact-form", submitContactForm)

--- a/BE/routes/chatRoutes.ts
+++ b/BE/routes/chatRoutes.ts
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const { requireAuth } = require('../middlewares/requireAuth');
+const { apiLimiter } = require('../middlewares/rateLimit');
+router.use(apiLimiter);
 
 import {
     getOrCreateDM,

--- a/BE/routes/customerRoutes.ts
+++ b/BE/routes/customerRoutes.ts
@@ -35,5 +35,5 @@ router.post("/leftSeminar", customerAuth(false), leftSeminar);
 router.post("/createEventFeedback", customerAuth(true), createFeedback);
 router.post("/follow/:expertId", customerAuth(false), followExpert);
 router.post("/unfollow/:expertId", customerAuth(false), unfollowExpert);
-router.post("/getMyPaymentHistory", sensitiveLimiter, customerAuth(false), getMyPaymentHistory);
+router.post("/getMyPaymentHistory", customerAuth(false), sensitiveLimiter, getMyPaymentHistory);
 module.exports = router;

--- a/BE/routes/customerRoutes.ts
+++ b/BE/routes/customerRoutes.ts
@@ -1,10 +1,13 @@
 const express = require("express");
 const router = express.Router();
 const { customerAuth } = require("../middlewares/requireAuth");
+const { apiLimiter, sensitiveLimiter } = require("../middlewares/rateLimit");
 const {
     filterExperts,
     filterSeminars,
     getExpertById,
+    followExpert,
+    unfollowExpert,
     getMyPaymentHistory,
 } = require('../controllers/customer.controller')
 const {
@@ -18,6 +21,9 @@ const {
     leftSeminar
 } = require('../controllers/groupChat.controller')
 
+// Baseline rate limiting for every customer route below.
+router.use(apiLimiter);
+
 router.post("/filterExperts", customerAuth(false), filterExperts);
 router.get("/getUser/:id",customerAuth(false),getExpertById)
 router.post("/filterSeminars", customerAuth(false), filterSeminars);
@@ -27,5 +33,7 @@ router.post("/cancelEvent", customerAuth(false), cancelEvent);
 router.post("/cancelPendingSeminar", customerAuth(false), cancelPendingSeminar);
 router.post("/leftSeminar", customerAuth(false), leftSeminar);
 router.post("/createEventFeedback", customerAuth(true), createFeedback);
-router.post("/getMyPaymentHistory", customerAuth(false), getMyPaymentHistory);
+router.post("/follow/:expertId", customerAuth(false), followExpert);
+router.post("/unfollow/:expertId", customerAuth(false), unfollowExpert);
+router.post("/getMyPaymentHistory", sensitiveLimiter, customerAuth(false), getMyPaymentHistory);
 module.exports = router;

--- a/BE/routes/expertRoutes.ts
+++ b/BE/routes/expertRoutes.ts
@@ -1,6 +1,8 @@
 const express = require("express");
 const router = express.Router();
 const { expertAuth, requireAuth } = require("../middlewares/requireAuth");
+const { apiLimiter } = require("../middlewares/rateLimit");
+router.use(apiLimiter);
 const {
     updateTimeSlots,
     getDailyTimeSlots,

--- a/BE/routes/friendInvitationRoutes.ts
+++ b/BE/routes/friendInvitationRoutes.ts
@@ -1,5 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const { apiLimiter } = require("../middlewares/rateLimit");
+router.use(apiLimiter);
 
 const { inviteFriend, acceptInvitation, rejectInvitation, removeFriend } = require("../controllers/friendInvitation.controller");
 

--- a/BE/routes/groupChatRoutes.ts
+++ b/BE/routes/groupChatRoutes.ts
@@ -25,6 +25,10 @@ const {
 } = require("../controllers/groupChat.controller");
 
 const { requireAuth, expertAuth } = require("../middlewares/requireAuth");
+const { apiLimiter } = require("../middlewares/rateLimit");
+
+// Rate-limit every group-chat route (mirrors authRoutes / customerRoutes).
+router.use(apiLimiter);
 
 // IMPORTANT: Specific routes must come before parameterized routes
 router.get(

--- a/BE/routes/meetingAnalyticsRoutes.ts
+++ b/BE/routes/meetingAnalyticsRoutes.ts
@@ -2,12 +2,16 @@ const express = require("express");
 const router = express.Router();
 const { requireAuth } = require("../middlewares/requireAuth");
 const meetingAnalyticsController = require("../controllers/meetingAnalytics.controller");
+const { apiLimiter, sensitiveLimiter } = require("../middlewares/rateLimit");
+
+// Baseline rate limiting for every meeting-analytics route below.
+router.use(apiLimiter);
 
 // create a new MeetingAnalytics record
-router.post("/create", requireAuth(), meetingAnalyticsController.createMeetingAnalytics);
+router.post("/create", sensitiveLimiter, requireAuth(), meetingAnalyticsController.createMeetingAnalytics);
 
 // update an existing MeetingAnalytics record (add feedback, update times, etc.)
-router.post("/update", requireAuth(), meetingAnalyticsController.updateMeetingAnalytics);
+router.post("/update", sensitiveLimiter, requireAuth(), meetingAnalyticsController.updateMeetingAnalytics);
 
 // get meeting analytics by referenceId (eventId or groupChatId)
 router.post("/get", requireAuth(), meetingAnalyticsController.getMeetingAnalytics);

--- a/BE/routes/meetingAnalyticsRoutes.ts
+++ b/BE/routes/meetingAnalyticsRoutes.ts
@@ -8,10 +8,10 @@ const { apiLimiter, sensitiveLimiter } = require("../middlewares/rateLimit");
 router.use(apiLimiter);
 
 // create a new MeetingAnalytics record
-router.post("/create", sensitiveLimiter, requireAuth(), meetingAnalyticsController.createMeetingAnalytics);
+router.post("/create", requireAuth(), sensitiveLimiter, meetingAnalyticsController.createMeetingAnalytics);
 
 // update an existing MeetingAnalytics record (add feedback, update times, etc.)
-router.post("/update", sensitiveLimiter, requireAuth(), meetingAnalyticsController.updateMeetingAnalytics);
+router.post("/update", requireAuth(), sensitiveLimiter, meetingAnalyticsController.updateMeetingAnalytics);
 
 // get meeting analytics by referenceId (eventId or groupChatId)
 router.post("/get", requireAuth(), meetingAnalyticsController.getMeetingAnalytics);

--- a/BE/routes/meetingRoutes.ts
+++ b/BE/routes/meetingRoutes.ts
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const { requireAuth } = require('../middlewares/requireAuth');
+const { apiLimiter } = require('../middlewares/rateLimit');
+router.use(apiLimiter);
 
 import { meetingChatSyncGate } from '../middlewares/meetingChatSyncGate';
 import {

--- a/BE/server.ts
+++ b/BE/server.ts
@@ -8,6 +8,7 @@ const cookieParser = require("cookie-parser");
 const path = require("path");
 const session = require("express-session");
 const passport = require("./config/passport");
+const { csrfProtection, csrfErrorHandler } = require("./config/csrf");
 const imageUploadRoutes = require("./routes/imageUploadRoutes");
 const fetchImageRoute = require("./routes/fetchImageRoute");
 
@@ -43,7 +44,7 @@ const corsOptions = {
     origin: [process.env.FE_URL, "https://www.wisdomlinked.com", "http://localhost:3000", jitOrigin].filter(Boolean),
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
     credentials: true,
-    allowedHeaders: ['Content-Type', 'Authorization']
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token']
 };
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions)); // Pre-flight handling
@@ -68,6 +69,8 @@ app.use(session({
 app.use(passport.initialize());
 app.use(passport.session());
 
+app.use(csrfProtection);
+
 // register the routes
 app.use("/api/auth", authRoutes);
 app.use("/api/invite-friend", friendInvitationRoutes);
@@ -81,6 +84,8 @@ app.use("/api", contactRoutes);
 app.use("/api/meeting-analytics", meetingAnalyticsRoutes);
 app.use("/api/chat", chatRoutes);
 app.use("/api/meeting", meetingRoutes);
+
+app.use(csrfErrorHandler);
 
 app.use(express.static('./uploads'));
 app.get('/uploads/*', (req, res) => {

--- a/BE/services/utils.ts
+++ b/BE/services/utils.ts
@@ -68,6 +68,41 @@ exports.sendPasswordResetOTP = async (targetEmail, htmlContent) => {
   }
 };
 
+exports.sendEmailChangeVerification = async (targetEmail, confirmCode) => {
+  const link = `${process.env.FE_URL}/verify-email-change/${confirmCode}`;
+  const html = `<div style="font-family: Arial, sans-serif; max-width: 520px; margin: 0 auto; background: #ffffff; border-radius: 16px; overflow: hidden; border: 1px solid #e2e8f0;">
+            <div style="background: linear-gradient(135deg, #234C6A 0%, #456882 100%); padding: 32px 24px; text-align: center;">
+                <h1 style="color: #ffffff; font-size: 24px; margin: 0; font-weight: 700; letter-spacing: 2px;">WISDOMLINKED</h1>
+            </div>
+            <div style="padding: 32px 24px;">
+                <h2 style="color: #1e293b; font-size: 22px; margin: 0 0 12px 0;">Confirm your email address</h2>
+                <p style="color: #475569; font-size: 15px; line-height: 1.6; margin: 0 0 24px 0;">You asked to set this email as the address for your WisdomLinked account. Click the button below to confirm it's really you.</p>
+                <div style="text-align: center; margin: 24px 0;">
+                    <a href="${link}" style="display: inline-block; background: linear-gradient(135deg, #234C6A 0%, #456882 100%); color: #ffffff; text-decoration: none; padding: 14px 40px; border-radius: 12px; font-size: 16px; font-weight: 600; letter-spacing: 0.5px;">Confirm Email</a>
+                </div>
+                <p style="color: #94a3b8; font-size: 13px; line-height: 1.5; margin: 24px 0 0 0;">This link expires in 24 hours. If you didn't request this, you can safely ignore this email — your account is unchanged.</p>
+            </div>
+            <div style="background: #f8fafc; padding: 16px 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+                <p style="color: #94a3b8; font-size: 12px; margin: 0;">&copy; ${new Date().getFullYear()} WisdomLinked. All rights reserved.</p>
+            </div>
+        </div>`;
+  const msg = {
+    to: targetEmail,
+    from: {
+      name: "WisdomLinked Support",
+      email: noReplyEmail,
+    },
+    subject: "Confirm Your Email - WisdomLinked",
+    html,
+  };
+  try {
+    await sgMail.send(msg);
+  } catch (error) {
+    console.error("Error sending email-change verification via SendGrid:", error.message);
+    throw error;
+  }
+};
+
 exports.sendContactDetails = async (targetEmail, name, email, demand) => {
   const html = `
       <h3>New Contact Request</h3>

--- a/BE/services/utils.ts
+++ b/BE/services/utils.ts
@@ -5,6 +5,8 @@ const noReplyEmail = "noreply@wisdomlinked.com";
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
+exports.escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 exports.getCurrentDateString = () => {
   const date = new Date();
   const day = String(date.getDate()).padStart(2, "0");

--- a/BE/services/wechatOAuth.ts
+++ b/BE/services/wechatOAuth.ts
@@ -1,0 +1,168 @@
+// WeChat website (QR / web) OAuth — server-side flow.
+//
+// WeChat does NOT use a passport strategy here; it is two plain HTTP calls:
+//   1. exchange `code` -> access_token (+ openid / unionid)
+//   2. fetch userinfo (nickname, headimgurl, unionid)
+// We then find-or-create a local user keyed on oauthProvider:'wechat' + oauthId.
+//
+// WeChat returns no email, but the app's auth/session layer is email-keyed
+// (JWT { email }, requireAuth/getMe look up by email). So new WeChat users are
+// created with a synthetic placeholder email (wechat_<oauthId>@wechat.local) and
+// sent to the complete-profile / bind-email step to add a real email later.
+
+const WECHAT_QRCONNECT_URL = "https://open.weixin.qq.com/connect/qrconnect";
+const WECHAT_ACCESS_TOKEN_URL = "https://api.weixin.qq.com/sns/oauth2/access_token";
+const WECHAT_USERINFO_URL = "https://api.weixin.qq.com/sns/userinfo";
+
+const WECHAT_PLACEHOLDER_EMAIL_DOMAIN = "wechat.local";
+
+export type WeChatProfile = {
+  oauthId: string;
+  nickname: string;
+  headimgurl: string;
+};
+
+type FindOrCreateDeps = {
+  UserModel?: any;
+  importPhoto?: (user: any, url: string | null | undefined) => Promise<unknown>;
+  createGeneralChat?: (userId: any) => Promise<unknown>;
+  sendApprovalEmail?: (username: string) => unknown;
+};
+
+// True for emails minted for WeChat-only accounts that still need a real email.
+export function isWeChatPlaceholderEmail(email: string | undefined | null): boolean {
+  return String(email || "").toLowerCase().endsWith(`@${WECHAT_PLACEHOLDER_EMAIL_DOMAIN}`);
+}
+
+function wechatPlaceholderEmail(oauthId: string): string {
+  return `wechat_${oauthId}@${WECHAT_PLACEHOLDER_EMAIL_DOMAIN}`;
+}
+
+// Mirror the OAUTH_BASE logic in config/passport.ts (handles nginx SSL termination).
+function oauthBase(): string {
+  const feUrl = (process.env.FE_URL || "").replace(/\/$/, "");
+  const isLocal = feUrl.includes("localhost") || feUrl.includes("127.0.0.1");
+  return isLocal
+    ? feUrl
+    : feUrl.replace(/:\d+$/, "").replace("http://", "https://");
+}
+
+// Build the WeChat QR-connect redirect URL. `state` is already encodeURIComponent'd
+// by the route (same as the Google flow); WeChat echoes it back verbatim.
+export function buildWeChatAuthUrl(state: string): string {
+  const appid = process.env.WECHAT_APP_ID || "";
+  const redirectUri = encodeURIComponent(`${oauthBase()}/api/auth/wechat/callback`);
+  return (
+    `${WECHAT_QRCONNECT_URL}?appid=${appid}` +
+    `&redirect_uri=${redirectUri}` +
+    `&response_type=code&scope=snsapi_login&state=${state}#wechat_redirect`
+  );
+}
+
+async function getJson(url: string, fetchFn: typeof fetch): Promise<any> {
+  const res = await fetchFn(url, { signal: AbortSignal.timeout(15000) });
+  // WeChat returns 200 with a JSON body (sometimes text/plain content-type).
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`WeChat returned a non-JSON response: ${text.slice(0, 200)}`);
+  }
+}
+
+// Exchange the OAuth `code` for the user's WeChat profile.
+// Throws on WeChat error bodies (errcode/errmsg) from either call.
+export async function exchangeCodeForUser(
+  code: string,
+  deps: { fetchFn?: typeof fetch } = {},
+): Promise<WeChatProfile> {
+  const fetchFn = deps.fetchFn || globalThis.fetch;
+  const appid = process.env.WECHAT_APP_ID || "";
+  const secret = process.env.WECHAT_APP_SECRET || "";
+
+  const tokenUrl =
+    `${WECHAT_ACCESS_TOKEN_URL}?appid=${encodeURIComponent(appid)}` +
+    `&secret=${encodeURIComponent(secret)}` +
+    `&code=${encodeURIComponent(code)}&grant_type=authorization_code`;
+  const tokenRes = await getJson(tokenUrl, fetchFn);
+  if (tokenRes.errcode) {
+    throw new Error(`WeChat access_token error ${tokenRes.errcode}: ${tokenRes.errmsg}`);
+  }
+
+  const { access_token: accessToken, openid } = tokenRes;
+  if (!accessToken || !openid) {
+    throw new Error("WeChat access_token response missing access_token/openid");
+  }
+
+  const userinfoUrl =
+    `${WECHAT_USERINFO_URL}?access_token=${encodeURIComponent(accessToken)}` +
+    `&openid=${encodeURIComponent(openid)}&lang=en`;
+  const info = await getJson(userinfoUrl, fetchFn);
+  if (info.errcode) {
+    throw new Error(`WeChat userinfo error ${info.errcode}: ${info.errmsg}`);
+  }
+
+  // Prefer unionid (stable across the open platform) over openid (per-app).
+  return {
+    oauthId: info.unionid || info.openid || openid,
+    nickname: info.nickname || "",
+    headimgurl: info.headimgurl || "",
+  };
+}
+
+// Find an existing WeChat user by oauthId, or create a new one with a placeholder email.
+// Returns { user, isNew } in the same shape as findOrCreateOAuthUser (config/passport.ts).
+export async function findOrCreateWeChatUser(
+  profile: WeChatProfile,
+  deps: FindOrCreateDeps = {},
+): Promise<{ user: any; isNew: boolean }> {
+  const User = deps.UserModel || require("../models/User");
+  const importPhoto =
+    deps.importPhoto || require("./oauthProfilePhoto").importOAuthProfilePhoto;
+
+  let user = await User.findOne({ oauthProvider: "wechat", oauthId: profile.oauthId });
+  if (user) {
+    await importPhoto(user, profile.headimgurl);
+    return { user, isNew: false };
+  }
+
+  user = new User({
+    email: wechatPlaceholderEmail(profile.oauthId),
+    username: profile.nickname || "WeChat User",
+    oauthProvider: "wechat",
+    oauthId: profile.oauthId,
+    role: "customer",
+    status: "review", // OAuth users still need admin approval
+  });
+  await user.save();
+
+  // Same new-user side effects as the Google flow (lazy-required to avoid cycles).
+  try {
+    const createGeneralChat =
+      deps.createGeneralChat ||
+      require("../controllers/groupChat.controller").createGeneralChatAndJoinGlobalChat;
+    await createGeneralChat(user._id);
+  } catch (e: any) {
+    console.error("[WeChat OAuth] createGeneralChat error:", e.message);
+  }
+
+  try {
+    const sendApprovalEmail =
+      deps.sendApprovalEmail ||
+      require("./notifications").sendEmailNewUserAccountApproval;
+    sendApprovalEmail(user.username);
+  } catch (e: any) {
+    console.error("[WeChat OAuth] sendEmail error:", e.message);
+  }
+
+  await importPhoto(user, profile.headimgurl);
+
+  return { user, isNew: true };
+}
+
+module.exports = {
+  buildWeChatAuthUrl,
+  exchangeCodeForUser,
+  findOrCreateWeChatUser,
+  isWeChatPlaceholderEmail,
+};

--- a/BE/tests/csrf.test.ts
+++ b/BE/tests/csrf.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert';
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const request = require('supertest');
+const { csrfProtection, csrfErrorHandler } = require('../config/csrf');
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(cookieParser());
+    app.use(csrfProtection);
+    app.get('/csrf-token', (req: any, res: any) => res.json({ csrfToken: req.csrfToken() }));
+    app.get('/read', (_req: any, res: any) => res.json({ ok: true }));
+    app.post('/change', (_req: any, res: any) => res.json({ ok: true }));
+    app.use(csrfErrorHandler);
+    return app;
+}
+
+test('POST without a CSRF token is rejected with 403 EBADCSRFTOKEN', async () => {
+    const res = await request(buildApp()).post('/change').send({});
+    assert.equal(res.status, 403);
+    assert.equal(res.body.code, 'EBADCSRFTOKEN');
+});
+
+test('GET issues a token and a POST carrying it succeeds', async () => {
+    const agent = request.agent(buildApp());
+    const tok = await agent.get('/csrf-token');
+    assert.equal(tok.status, 200);
+    assert.ok(tok.body.csrfToken, 'csrf-token endpoint should return a token');
+
+    const ok = await agent.post('/change').set('X-CSRF-Token', tok.body.csrfToken).send({});
+    assert.equal(ok.status, 200);
+    assert.deepEqual(ok.body, { ok: true });
+});
+
+test('a token without its matching secret cookie is rejected', async () => {
+    const app = buildApp();
+    const tok = await request(app).get('/csrf-token');
+    const res = await request(app).post('/change').set('X-CSRF-Token', tok.body.csrfToken).send({});
+    assert.equal(res.status, 403);
+});
+
+test('GET requests pass without any token', async () => {
+    const res = await request(buildApp()).get('/read');
+    assert.equal(res.status, 200);
+});

--- a/BE/tests/getExpertById.populate.test.ts
+++ b/BE/tests/getExpertById.populate.test.ts
@@ -48,7 +48,9 @@ test("getExpertById populates the booking fields the overlap check needs", async
     await getExpertById(req, res);
 
     assert.equal(res.statusCode, 200);
-    assert.equal(res.body?.result, fakeExpert);
+
+    assert.equal(res.body?.result?._id, fakeExpert._id);
+    assert.equal(res.body?.result?.username, fakeExpert.username);
 
     const names = pathNames(capturedPaths);
     // Existing profile data must still be populated.

--- a/BE/tests/wechatOAuth.test.ts
+++ b/BE/tests/wechatOAuth.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  buildWeChatAuthUrl,
+  exchangeCodeForUser,
+  findOrCreateWeChatUser,
+  isWeChatPlaceholderEmail,
+} = require("../services/wechatOAuth");
+
+// fetch stub that returns a queue of JSON bodies (WeChat replies 200 + JSON text).
+function fakeFetch(bodies: any[]) {
+  let i = 0;
+  return async (_url: string) => ({
+    text: async () => JSON.stringify(bodies[i++]),
+  });
+}
+
+// A stand-in for the Mongoose User model: constructable + static findOne.
+function makeFakeUserModel(existing: any) {
+  const created: any[] = [];
+  function FakeUser(this: any, doc: any) {
+    Object.assign(this, doc);
+    this._id = "fake-user-id";
+    this.save = async () => this;
+    created.push(this);
+  }
+  (FakeUser as any).findOne = async () => existing;
+  (FakeUser as any)._created = created;
+  return FakeUser as any;
+}
+
+test("isWeChatPlaceholderEmail detects synthetic addresses only", () => {
+  assert.equal(isWeChatPlaceholderEmail("wechat_abc@wechat.local"), true);
+  assert.equal(isWeChatPlaceholderEmail("WECHAT_ABC@WECHAT.LOCAL"), true);
+  assert.equal(isWeChatPlaceholderEmail("real@gmail.com"), false);
+  assert.equal(isWeChatPlaceholderEmail(""), false);
+  assert.equal(isWeChatPlaceholderEmail(null), false);
+});
+
+test("buildWeChatAuthUrl builds a qrconnect URL with encoded callback + state", () => {
+  const prevApp = process.env.WECHAT_APP_ID;
+  const prevFe = process.env.FE_URL;
+  process.env.WECHAT_APP_ID = "wx_test_appid";
+  process.env.FE_URL = "https://staging.wisdomlinked.com";
+
+  const url = buildWeChatAuthUrl("STATE123");
+  assert.ok(url.startsWith("https://open.weixin.qq.com/connect/qrconnect?"));
+  assert.ok(url.includes("appid=wx_test_appid"));
+  assert.ok(url.includes("response_type=code"));
+  assert.ok(url.includes("scope=snsapi_login"));
+  assert.ok(url.includes("state=STATE123"));
+  assert.ok(url.endsWith("#wechat_redirect"));
+  // redirect_uri is URL-encoded and points at the BE callback.
+  assert.ok(
+    url.includes(
+      "redirect_uri=" +
+        encodeURIComponent("https://staging.wisdomlinked.com/api/auth/wechat/callback"),
+    ),
+  );
+
+  process.env.WECHAT_APP_ID = prevApp;
+  process.env.FE_URL = prevFe;
+});
+
+test("exchangeCodeForUser prefers unionid and returns profile fields", async () => {
+  const fetchFn = fakeFetch([
+    { access_token: "tok", openid: "openid_1" },
+    { openid: "openid_1", unionid: "union_1", nickname: "小明", headimgurl: "https://wx.example/a.png" },
+  ]);
+
+  const profile = await exchangeCodeForUser("the_code", { fetchFn });
+  assert.equal(profile.oauthId, "union_1"); // unionid preferred over openid
+  assert.equal(profile.nickname, "小明");
+  assert.equal(profile.headimgurl, "https://wx.example/a.png");
+});
+
+test("exchangeCodeForUser falls back to openid when no unionid", async () => {
+  const fetchFn = fakeFetch([
+    { access_token: "tok", openid: "openid_2" },
+    { openid: "openid_2", nickname: "No Union", headimgurl: "" },
+  ]);
+  const profile = await exchangeCodeForUser("code2", { fetchFn });
+  assert.equal(profile.oauthId, "openid_2");
+});
+
+test("exchangeCodeForUser throws on access_token errcode", async () => {
+  const fetchFn = fakeFetch([{ errcode: 40029, errmsg: "invalid code" }]);
+  await assert.rejects(() => exchangeCodeForUser("bad", { fetchFn }), /40029/);
+});
+
+test("exchangeCodeForUser throws on userinfo errcode", async () => {
+  const fetchFn = fakeFetch([
+    { access_token: "tok", openid: "openid_3" },
+    { errcode: 40003, errmsg: "invalid openid" },
+  ]);
+  await assert.rejects(() => exchangeCodeForUser("code3", { fetchFn }), /40003/);
+});
+
+test("findOrCreateWeChatUser returns existing user (isNew=false) when oauthId matches", async () => {
+  const existing = { _id: "u1", email: "real@gmail.com", oauthProvider: "wechat", oauthId: "union_1" };
+  let photoImported = false;
+  const UserModel = makeFakeUserModel(existing);
+
+  const result = await findOrCreateWeChatUser(
+    { oauthId: "union_1", nickname: "x", headimgurl: "https://wx/p.png" },
+    {
+      UserModel,
+      importPhoto: async () => { photoImported = true; },
+    },
+  );
+
+  assert.equal(result.isNew, false);
+  assert.equal(result.user, existing);
+  assert.equal(photoImported, true);
+  assert.equal(UserModel._created.length, 0); // nothing created
+});
+
+test("findOrCreateWeChatUser creates a placeholder-email user (isNew=true) and runs side effects", async () => {
+  const UserModel = makeFakeUserModel(null); // no existing user
+  let chatUserId: any = null;
+  let approvalUsername = "";
+  let photoUrl = "";
+
+  const result = await findOrCreateWeChatUser(
+    { oauthId: "union_new", nickname: "Jane", headimgurl: "https://wx/jane.png" },
+    {
+      UserModel,
+      importPhoto: async (_u: any, url: string) => { photoUrl = url; },
+      createGeneralChat: async (id: any) => { chatUserId = id; },
+      sendApprovalEmail: (name: string) => { approvalUsername = name; },
+    },
+  );
+
+  assert.equal(result.isNew, true);
+  assert.equal(result.user.oauthProvider, "wechat");
+  assert.equal(result.user.oauthId, "union_new");
+  assert.equal(result.user.email, "wechat_union_new@wechat.local"); // synthetic placeholder
+  assert.equal(result.user.username, "Jane");
+  assert.equal(result.user.role, "customer");
+  assert.equal(result.user.status, "review");
+  // side effects fired
+  assert.equal(chatUserId, "fake-user-id");
+  assert.equal(approvalUsername, "Jane");
+  assert.equal(photoUrl, "https://wx/jane.png");
+});
+
+test("findOrCreateWeChatUser falls back to 'WeChat User' when nickname is empty", async () => {
+  const UserModel = makeFakeUserModel(null);
+  const result = await findOrCreateWeChatUser(
+    { oauthId: "u_noname", nickname: "", headimgurl: "" },
+    { UserModel, importPhoto: async () => {}, createGeneralChat: async () => {}, sendApprovalEmail: () => {} },
+  );
+  assert.equal(result.user.username, "WeChat User");
+});

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -201,9 +201,12 @@ function App() {
       
       const path = window.location.pathname;
       const search = window.location.search;
+      if (path.startsWith('/user/')) {
+        return;
+      }
       if (
-        path.includes('/oauth-callback') || 
-        path.includes('/verification/') || 
+        path.includes('/oauth-callback') ||
+        path.includes('/verification/') ||
         path.includes('/auth-complete-profile') ||
         path.includes('/meeting/invite/') ||
         (path.includes('/login') && search.includes('error='))

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -11,6 +11,7 @@ import { updateLocation } from './actions/appActions';
 import { siteMap } from './actions/siteMap';
 import { isTheEventGoingOn } from './actions/common';
 import { autoLogin } from './actions/authActions';
+import { ensureCsrfToken } from './api/csrf';
 import { connectToRC, isRCConnected } from './services/rcRealtime';
 import 'swiper/swiper.min.css';
 import LeaveFeedback from './components/LeaveFeedback';
@@ -181,6 +182,7 @@ function App() {
   const [oldUserDetails, set_oldUserDetails] = useState(userDetails)
 
   useEffect(() => {
+    ensureCsrfToken();
     const storedUser = localStorage.getItem("currentUser");
     const currentUser: CurrentUser = JSON.parse(
       storedUser && storedUser !== "undefined" ? storedUser : "{}"

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -15,6 +15,7 @@ import { connectToRC, isRCConnected } from './services/rcRealtime';
 import 'swiper/swiper.min.css';
 import LeaveFeedback from './components/LeaveFeedback';
 import VerifyEmail from './pages/VerifyEmail';
+import VerifyEmailChange from './pages/VerifyEmailChange';
 import ForgotPassword from './pages/ForgotPassword';
 
 // Lazy-loaded pages — only downloaded when the user navigates to them
@@ -55,6 +56,7 @@ const UnauthenticatedRoutes = () => {
         <Route path="/expertregister" element={<WLExpertRegister />} />
         <Route path="/forgotpassword" element={<ForgotPassword />} />
         <Route path="/verification/:email/:confirmCode" element={<VerifyEmail />} />
+        <Route path="/verify-email-change/:confirmCode" element={<VerifyEmailChange />} />
         <Route path="/meeting/invite/:token" element={<MeetingGuestInvite />} />
         <Route path="/login" element={<WLLogin />} />
         <Route path="/aboutus" element={
@@ -207,6 +209,7 @@ function App() {
       if (
         path.includes('/oauth-callback') ||
         path.includes('/verification/') ||
+        path.includes('/verify-email-change/') ||
         path.includes('/auth-complete-profile') ||
         path.includes('/meeting/invite/') ||
         (path.includes('/login') && search.includes('error='))

--- a/FE/src/api/api.ts
+++ b/FE/src/api/api.ts
@@ -127,6 +127,15 @@ export const verifyPasswordResetOTP = async ({ email, code }: any) => {
     }
 };
 
+export const confirmEmailChange = async ({ confirmCode }: any) => {
+    try {
+        const res = await api.post<any>("auth/confirmEmailChange", { confirmCode });
+        return res.data;
+    } catch (error) {
+        return { status: "FAIL", error: resolveUserFacingError(error) };
+    }
+}
+
 export const verifyRegistration = async ({ email, confirmCode }: any) => {
     try {
         const res = await api.post<any>("auth/verifyRegistration", { email, confirmCode });

--- a/FE/src/api/api.ts
+++ b/FE/src/api/api.ts
@@ -18,6 +18,7 @@ import {
     handleAuthApiFailure,
 } from "./apiErrorHandling";
 import { resolveUserFacingError } from "../utils/resolveUserFacingError";
+import { ensureCsrfToken, clearCsrfToken, needsCsrf, isCsrfError } from "./csrf";
 import { logoutUser } from "../actions/authActions";
 import { SetLoadingStatus } from "../actions/appActions";
 
@@ -30,6 +31,36 @@ const api = axios.create({
     withCredentials: true,
     baseURL: BASE_URL
 });
+
+api.interceptors.request.use(async (config) => {
+    if (needsCsrf(config.method)) {
+        const t = await ensureCsrfToken();
+        if (t) {
+            config.headers = config.headers || {};
+            (config.headers as any)['X-CSRF-Token'] = t;
+        }
+    }
+    return config;
+});
+
+api.interceptors.response.use(
+    (res) => res,
+    async (error) => {
+        const cfg = error?.config;
+        const resp = error?.response;
+        if (cfg && !cfg.__csrfRetried && isCsrfError(resp?.data, resp?.status)) {
+            cfg.__csrfRetried = true;
+            clearCsrfToken();
+            const t = await ensureCsrfToken();
+            if (t) {
+                cfg.headers = cfg.headers || {};
+                cfg.headers['X-CSRF-Token'] = t;
+                return api.request(cfg);
+            }
+        }
+        return Promise.reject(error);
+    }
+);
 
 // api.interceptors.request.use(
 //     (config) => {
@@ -556,10 +587,17 @@ export const callApi = async (
 
 
 
+        const headers: Record<string, string> = {};
+        if (needsCsrf(method)) {
+            const t = await ensureCsrfToken();
+            if (t) headers['X-CSRF-Token'] = t;
+        }
+
         let options: RequestInit = {
             method: method,
             body: formData,
-            credentials: 'include'
+            credentials: 'include',
+            headers,
         }
         return fetch(BASE_URL + url, options)
             .then(async (response: Response) => {

--- a/FE/src/api/api.ts
+++ b/FE/src/api/api.ts
@@ -314,6 +314,18 @@ export const createGroupChat = async (details: any) => {
     }
 };
 
+export const uploadSeminarCover = async (file: File): Promise<string | null> => {
+    try {
+        const formData = new FormData();
+        formData.append("media", file, file.name);
+        const res = await api.post("auth/uploadChatFile", formData);
+        return res.data?.chatFile || null;
+    } catch (err: any) {
+        checkForAuthorization(err);
+        return null;
+    }
+};
+
 export const createGroupChatByUser = async (details: any) => {
     try {
         const res = await api.post("group-chat/create-by-user", details);
@@ -832,6 +844,26 @@ export const getExpertById = async (id: any) => {
         const res = await api.get(`customer/getUser/${id}`);
 
         return res.data;
+    } catch (err: any) {
+        return checkForAuthorization(err);
+    }
+};
+
+// Follow / unfollow an expert. Returns { following, followerCount } from the
+// server (the source of truth) so the caller can reconcile optimistic UI.
+export const doFollowExpert = async (expertId: string) => {
+    try {
+        const res = await api.post(`customer/follow/${expertId}`);
+        return res.data as { following: boolean; followerCount: number };
+    } catch (err: any) {
+        return checkForAuthorization(err);
+    }
+};
+
+export const doUnfollowExpert = async (expertId: string) => {
+    try {
+        const res = await api.post(`customer/unfollow/${expertId}`);
+        return res.data as { following: boolean; followerCount: number };
     } catch (err: any) {
         return checkForAuthorization(err);
     }

--- a/FE/src/api/chatApi.ts
+++ b/FE/src/api/chatApi.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { resolveUserFacingError } from '../utils/resolveUserFacingError';
+import { ensureCsrfToken, clearCsrfToken, needsCsrf, isCsrfError } from './csrf';
 
 export type ChatApiResult<T> = { ok: true; data: T } | { ok: false; error: string };
 
@@ -31,6 +32,36 @@ const api = axios.create({
     withCredentials: true,
     baseURL: BASE_URL,
 });
+
+api.interceptors.request.use(async (config) => {
+    if (needsCsrf(config.method)) {
+        const t = await ensureCsrfToken();
+        if (t) {
+            config.headers = config.headers || {};
+            (config.headers as any)['X-CSRF-Token'] = t;
+        }
+    }
+    return config;
+});
+
+api.interceptors.response.use(
+    (res) => res,
+    async (error) => {
+        const cfg = error?.config;
+        const resp = error?.response;
+        if (cfg && !cfg.__csrfRetried && isCsrfError(resp?.data, resp?.status)) {
+            cfg.__csrfRetried = true;
+            clearCsrfToken();
+            const t = await ensureCsrfToken();
+            if (t) {
+                cfg.headers = cfg.headers || {};
+                cfg.headers['X-CSRF-Token'] = t;
+                return api.request(cfg);
+            }
+        }
+        return Promise.reject(error);
+    }
+);
 
 export const CHAT_HISTORY_PAGE_SIZE = 50;
 

--- a/FE/src/api/csrf.ts
+++ b/FE/src/api/csrf.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+
+let base = process.env.REACT_APP_API_BASE_URL || '/api';
+if (base && !base.endsWith('/')) base += '/';
+
+let token: string | null = null;
+let inflight: Promise<string | null> | null = null;
+
+const SAFE_METHODS = ['get', 'head', 'options'];
+
+export const needsCsrf = (method?: string) =>
+    !SAFE_METHODS.includes((method || 'get').toLowerCase());
+
+export const ensureCsrfToken = async (): Promise<string | null> => {
+    if (token) return token;
+    if (!inflight) {
+        inflight = axios
+            .get(`${base}auth/csrf-token`, { withCredentials: true })
+            .then((res) => {
+                token = res?.data?.csrfToken ?? null;
+                return token;
+            })
+            .catch(() => null)
+            .finally(() => {
+                inflight = null;
+            });
+    }
+    return inflight;
+};
+
+export const clearCsrfToken = () => {
+    token = null;
+};
+
+export const isCsrfError = (data: any, status?: number) =>
+    status === 403 && (data?.code === 'EBADCSRFTOKEN' || /csrf/i.test(String(data?.error || '')));

--- a/FE/src/components/MentorCard.tsx
+++ b/FE/src/components/MentorCard.tsx
@@ -118,9 +118,6 @@ const MentorCard: React.FC<MentorCardProps> = ({
           >
             {isFollowing ? 'Following' : 'Follow +'}
           </button>
-          <span className="text-[10px] font-medium tabular-nums text-[#7A7A72]">
-            {followerCount.toLocaleString()} followers
-          </span>
         </div>
       ) : null}
 

--- a/FE/src/components/SocialAuthBlock.tsx
+++ b/FE/src/components/SocialAuthBlock.tsx
@@ -24,6 +24,13 @@ const GoogleIcon = () => (
   </svg>
 );
 
+const WeChatIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="#07C160" xmlns="http://www.w3.org/2000/svg" className="shrink-0">
+    <path d="M8.69 4C4.62 4 1.33 6.77 1.33 10.19c0 1.97 1.1 3.73 2.82 4.88l-.7 2.13 2.46-1.24c.88.26 1.82.41 2.78.41.24 0 .48-.01.71-.03a4.7 4.7 0 0 1-.2-1.34c0-2.9 2.82-5.25 6.3-5.25.23 0 .46.01.69.04C15.5 6.05 12.46 4 8.69 4zM6.3 8.6a.92.92 0 1 1 0-1.84.92.92 0 0 1 0 1.84zm4.78 0a.92.92 0 1 1 0-1.84.92.92 0 0 1 0 1.84z"/>
+    <path d="M22.67 15c0-2.87-2.79-5.2-6.07-5.2-3.42 0-6.07 2.39-6.07 5.2 0 2.82 2.65 5.2 6.07 5.2.71 0 1.42-.12 2.07-.32l1.94.99-.55-1.7C21.6 18.27 22.67 16.71 22.67 15zm-7.93-.84a.77.77 0 1 1 0-1.53.77.77 0 0 1 0 1.53zm3.84 0a.77.77 0 1 1 0-1.53.77.77 0 0 1 0 1.53z"/>
+  </svg>
+);
+
 export default function SocialAuthBlock({ role, redirect }: { role?: string; redirect?: string } = {}) {
   const navigateTo = (url: string) => {
     window.location.assign(url);
@@ -48,6 +55,14 @@ export default function SocialAuthBlock({ role, redirect }: { role?: string; red
           aria-label="Continue with Google"
         >
           <GoogleIcon /> <span className="hidden sm:inline">Google</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => handleSocialClick('wechat')}
+          className="flex items-center justify-center gap-2 w-full flex-1 min-w-0 py-3 px-4 rounded-xl border border-slate-200 bg-white text-slate-700 text-sm font-medium hover:border-slate-300 hover:bg-slate-50 transition-colors"
+          aria-label="Continue with WeChat"
+        >
+          <WeChatIcon /> <span className="hidden sm:inline">WeChat</span>
         </button>
       </div>
     </div>

--- a/FE/src/components/dashboard/ExpertProfile.booking.test.tsx
+++ b/FE/src/components/dashboard/ExpertProfile.booking.test.tsx
@@ -96,7 +96,7 @@ vi.mock('./StudentExpertBookingPicker', () => ({
 
 vi.mock('./StudentBookingCheckout', () => ({
 
-  default: ({ onPaymentSuccess, onCancel }: any) => (
+  default: ({ onPaymentSuccess, onCancel, cancelLabel = 'Cancel pay' }: any) => (
 
     <div data-testid="student-checkout">
 
@@ -108,7 +108,7 @@ vi.mock('./StudentBookingCheckout', () => ({
 
       <button type="button" onClick={onCancel}>
 
-        Cancel pay
+        {cancelLabel}
 
       </button>
 
@@ -270,21 +270,20 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
+
+    // Review step first, with Change time, before continuing to payment.
+    expect(await screen.findByText('Review your booking')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change time/i })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /continue to payment/i }));
 
-    expect(await screen.findByTestId('booking-confirmation-modal')).toBeInTheDocument();
-    expect(screen.queryByTestId('student-checkout')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /proceed to payment/i }));
+    expect(await screen.findByTestId('student-checkout')).toBeInTheDocument();
 
     expect(String(window.location.href)).not.toContain('customerdashboard/search');
-    expect(await screen.findByTestId('student-checkout')).toBeInTheDocument();
   });
 
 
 
-  it('shows confirmation modal with booking details before checkout', async () => {
+  it('opens checkout directly without the old confirmation modal', async () => {
     render(
       <Provider store={store}>
         <ExpertProfile mentor={mentor} onBack={vi.fn()} />
@@ -293,16 +292,11 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
-    fireEvent.click(screen.getByRole('button', { name: /continue to payment/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /continue to payment/i }));
 
-    const modal = await screen.findByTestId('booking-confirmation-modal');
-    expect(within(modal).getByText('Dr. Smith')).toBeInTheDocument();
-    expect(within(modal).getByText('1:1 session')).toBeInTheDocument();
-    expect(within(modal).getByText('60 min')).toBeInTheDocument();
-    expect(within(modal).getByText('$60.00')).toBeInTheDocument();
-    expect(within(modal).getByText('UTC')).toBeInTheDocument();
-    expect(screen.queryByTestId('student-checkout')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('student-checkout')).toBeInTheDocument();
+    expect(screen.queryByTestId('booking-confirmation-modal')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /proceed to payment/i })).not.toBeInTheDocument();
   });
 
 
@@ -325,10 +319,7 @@ describe('ExpertProfile booking', () => {
 
     fireEvent.click(screen.getByTestId('pick-slot'));
 
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
-
-    fireEvent.click(screen.getByRole('button', { name: /continue to payment/i }));
-    fireEvent.click(screen.getByRole('button', { name: /proceed to payment/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /continue to payment/i }));
 
     fireEvent.click(screen.getByRole('button', { name: /pay mock/i }));
 
@@ -414,9 +405,8 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
 
-    const summarySection = screen.getByText('Booking summary').closest('div') as HTMLElement;
+    const summarySection = (await screen.findByText('Review your booking')).closest('div') as HTMLElement;
     expect(within(summarySection).getByText(/2:00 PM.*3:00 PM.*\(UTC\)/i)).toBeInTheDocument();
   });
 
@@ -455,7 +445,7 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
+    await screen.findByText('Review your booking');
 
     const ratesSection = () =>
       screen.getByRole('heading', { name: 'Rates' }).closest('section') as HTMLElement;
@@ -482,33 +472,15 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
 
     const summarySection = () =>
-      screen.getByText('Booking summary').closest('div') as HTMLElement;
+      screen.getByText('Review your booking').closest('div') as HTMLElement;
 
+    await screen.findByText('Review your booking');
     expect(within(summarySection()).getByText('60 min')).toBeInTheDocument();
     expect(within(summarySection()).getByText('$60.00')).toBeInTheDocument();
     expect(screen.getByText(/fixed for this booking/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '90 min' })).not.toBeInTheDocument();
-  });
-
-  it('shows selected slot summary before Review booking', async () => {
-    render(
-      <Provider store={store}>
-        <ExpertProfile mentor={mentor} onBack={vi.fn()} />
-      </Provider>,
-    );
-
-    await screen.findByTestId('slot-picker');
-    fireEvent.click(screen.getByTestId('pick-slot'));
-
-    const summary = await screen.findByTestId('selected-slot-summary');
-    expect(summary).toBeInTheDocument();
-    expect(within(summary).getByText('Your selected appointment')).toBeInTheDocument();
-    expect(within(summary).getByText('60 min')).toBeInTheDocument();
-    expect(within(summary).getByText('$60.00')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /review booking/i })).toBeInTheDocument();
   });
 
   it('unlocks appointment duration after Change time', async () => {
@@ -520,7 +492,7 @@ describe('ExpertProfile booking', () => {
 
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot'));
-    fireEvent.click(screen.getByRole('button', { name: /review booking/i }));
+    await screen.findByText('Review your booking');
     fireEvent.click(screen.getByRole('button', { name: /change time/i }));
 
     const btn90 = screen.getByRole('button', { name: '90 min' });
@@ -570,9 +542,8 @@ describe('ExpertProfile booking', () => {
     await screen.findByTestId('slot-picker');
     fireEvent.click(screen.getByTestId('pick-slot-filter'));
 
-    expect(await screen.findByText('Booking summary')).toBeInTheDocument();
+    expect(await screen.findByText('Review your booking')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /review booking/i })).not.toBeInTheDocument();
   });
 
 });
-

--- a/FE/src/components/dashboard/ExpertProfile.tsx
+++ b/FE/src/components/dashboard/ExpertProfile.tsx
@@ -5,7 +5,6 @@ import {
   BookOpen,
   Calendar,
   ChevronDown,
-  Clock,
   FileText,
   MapPin,
   MessageSquare,
@@ -15,12 +14,10 @@ import {
 } from 'lucide-react';
 import type { MentorCardProps } from '../MentorCard';
 import { useAppSelector } from '../../store';
-import { SERVICE_LABELS } from '../../constants/serviceOptions';
 import FilePreviewModal from '../../pages/Dashboard/FilePreviewModal';
 import { hasResumeForPreview, resolveResumePublicUrl } from '../../utils/resumeUrl';
 import StudentExpertBookingPicker from './StudentExpertBookingPicker';
 import StudentBookingCheckout from './StudentBookingCheckout';
-import BookingConfirmationModal from './BookingConfirmationModal';
 import { createGroupChatByUser, getExpertById, profileImageFetch, addMemberToPendingGroup } from '../../api/api';
 import { resolveProfileImageSrc } from '../../utils/profileImage';
 import { normalizeExpertPrice } from '../../utils/schedulingSlots';
@@ -31,19 +28,13 @@ import {
   normalizeAppointmentDurations,
   type AppointmentDurationMinutes,
 } from '../../utils/appointmentDurations';
-import { detectUserTimeZone, formatBookingConfirmation, formatPickedSlotWhenDisplay } from '../../utils/schedulingTimezone';
+import { detectUserTimeZone, formatPickedSlotWhenDisplay } from '../../utils/schedulingTimezone';
 import { SetLoadingStatus } from '../../actions/appActions';
 
 type BookingStep = 'pick' | 'review' | 'pay' | 'success';
 
 const aiHeadshotUrl = (seed: string) =>
   `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${encodeURIComponent(seed)}`;
-
-function extractExperienceYears(experience: string) {
-  // Examples: "8+ yrs", "15+ yrs"
-  const m = experience.match(/(\d+)/);
-  return m ? Number(m[1]) : 0;
-}
 
 export default function ExpertProfile({
   mentor,
@@ -68,10 +59,6 @@ export default function ExpertProfile({
 }) {
   const dispatch = useDispatch();
   const { auth: { userDetails } } = useAppSelector((state: any) => state);
-  const experienceYears = useMemo(
-    () => extractExperienceYears(mentor.experience),
-    [mentor.experience],
-  );
 
   const [expertDetails, setExpertDetails] = useState<any>(null);
   const [expertLoading, setExpertLoading] = useState(false);
@@ -125,47 +112,14 @@ export default function ExpertProfile({
     );
   }, [expertDetails, offeredDurations]);
 
-  const oneToOneRate = useMemo(
-    () => expertHourlyRate ?? 60 + experienceYears * 18,
-    [experienceYears, expertHourlyRate],
-  );
   /** Hourly rate shown to students — only when expert published a price. */
   const publishedOneToOneRate = expertHourlyRate;
-  const seminarRate = useMemo(
-    () => 35 + experienceYears * 10,
-    [experienceYears],
-  );
 
-  const supportsOneToOne = useMemo(
-    () =>
-      mentor.services.some(s => /1\s*[-–]?\s*on\s*[-–]?\s*1/i.test(s) || /1:1/i.test(s)) ||
-      mentor.services.some(s => SERVICE_LABELS.includes(s)),
-    [mentor.services],
-  );
-  const supportsSeminar = useMemo(
-    () => mentor.services.some(s => /seminar/i.test(s)),
-    [mentor.services],
-  );
-
-  const [serviceChoice, setServiceChoice] = useState<'oneToOne' | 'seminar'>(() => {
-    if (supportsOneToOne) return 'oneToOne';
-    if (supportsSeminar) return 'seminar';
-    return 'oneToOne';
-  });
-
-  const [selectedSlot, setSelectedSlot] = useState<{
-    day: string;
-    start: string; // HH:MM
-    end: string; // HH:MM
-  } | null>(null);
-
-  /** 1:1 only — price scales from hourly peak/off-peak rate. */
+  /** 1:1 session length — price scales from the expert's published hourly rate. */
   const [sessionDurationMinutes, setSessionDurationMinutes] = useState<30 | 60 | 90>(60);
 
   const [bookingStep, setBookingStep] = useState<BookingStep>('pick');
-  const [bookingSuccess, setBookingSuccess] = useState(false);
   const [bookingError, setBookingError] = useState<string | null>(null);
-  const [paymentConfirmOpen, setPaymentConfirmOpen] = useState(false);
   const [bookingViewerTz, setBookingViewerTz] = useState(
     () => userDetails?.timeZone || detectUserTimeZone(),
   );
@@ -180,27 +134,6 @@ export default function ExpertProfile({
 
   const [openFaqIndex, setOpenFaqIndex] = useState<number | null>(null);
   const [displayImage, setDisplayImage] = useState(() => aiHeadshotUrl(mentor.name));
-
-  const peakRate = 50;
-  const oneToOneOffPeakRate = Math.min(oneToOneRate, 45);
-  const seminarOffPeakRate = Math.min(seminarRate, 40);
-
-  const isPeakSlot = (slot: { day: string; start: string; end: string } | null) => {
-    if (!slot) return false;
-    const isWeekend = slot.day === 'Sat' || slot.day === 'Sun';
-    const startHour = Number(slot.start.split(':')[0] || 0);
-    // Dinner window (mock): 18:00 - 22:00
-    const isDinner = startHour >= 18 && startHour < 22;
-    return isWeekend || isDinner;
-  };
-
-  const oneToOneHourlyRate = isPeakSlot(selectedSlot) ? peakRate : oneToOneOffPeakRate;
-  const seminarSessionRate = isPeakSlot(selectedSlot) ? peakRate : seminarOffPeakRate;
-
-  const selectedRate =
-    serviceChoice === 'seminar'
-      ? seminarSessionRate
-      : oneToOneHourlyRate * (sessionDurationMinutes / 60);
 
   const hasLockedDuration = !!pickedStart;
 
@@ -218,11 +151,12 @@ export default function ExpertProfile({
       setPickedDuration(mins);
       setSessionDurationMinutes(mins);
       setBookingError(null);
-      if (bookingStep !== 'pick') {
-        setBookingStep('pick');
-      }
+      // Keep the flow inside one continuous popup: confirming a time in the
+      // picker advances straight to the review popup (which then continues to
+      // payment), with no intermediate sidebar step.
+      setBookingStep('review');
     },
-    [bookingStep],
+    [],
   );
 
   const clearPickedSlot = useCallback(() => {
@@ -239,29 +173,16 @@ export default function ExpertProfile({
     return computeBookingPriceDollars(pickedDuration, hourly);
   }, [pickedDuration, expertDetails?.price]);
 
-  const bookingConfirmationDetails = useMemo(() => {
-    if (!pickedStart || !pickedEnd) return null;
-    const formatted = formatBookingConfirmation(pickedStart, pickedEnd, bookingViewerTz);
-    return {
-      ...formatted,
-      sessionType: '1:1 session',
-      expertName: mentor.name,
-      sessionLengthMinutes: pickedDuration,
-      price: oneToOneSessionPrice,
-    };
-  }, [
-    pickedStart,
-    pickedEnd,
-    bookingViewerTz,
-    mentor.name,
-    pickedDuration,
-    oneToOneSessionPrice,
-  ]);
-
   const pickedSlotDisplay = useMemo(() => {
     if (!pickedStart || !pickedEnd) return null;
     return formatPickedSlotWhenDisplay(pickedStart, pickedEnd, bookingViewerTz);
   }, [pickedStart, pickedEnd, bookingViewerTz]);
+
+  const changeOneToOneTime = useCallback(() => {
+    clearPickedSlot();
+    void loadExpertDetails();
+    setBookingStep('pick');
+  }, [clearPickedSlot, loadExpertDetails]);
 
   const bookingEventTitle = useMemo(() => {
     const student = userDetails?.username || 'Student';
@@ -301,7 +222,6 @@ export default function ExpertProfile({
         if (response?.result) {
           dispatch({ type: 'updateUserDetails', payload: response.result });
         }
-        setBookingSuccess(true);
         setBookingStep('success');
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Booking failed. Please try again.';
@@ -324,90 +244,10 @@ export default function ExpertProfile({
 
   useEffect(() => {
     if (paymentReturnSuccess) {
-      setBookingSuccess(true);
       setBookingStep('success');
       onPaymentReturnHandled?.();
     }
   }, [paymentReturnSuccess, onPaymentReturnHandled]);
-
-  const availability = useMemo(() => {
-    // Mock schedule for seminar picker only.
-    const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-    return dayNames.map((day, idx) => {
-      const available = (idx + mentor.id) % 7 !== 6; // mostly available days
-      // Mix daytime and dinner-time slots so peak pricing is visible.
-      // Weekend and Thu/Fri often fall into evening windows.
-      const isWeekend = day === 'Sat' || day === 'Sun';
-      const isLateWeek = day === 'Thu' || day === 'Fri';
-      const startHour = isWeekend
-        ? 18 + ((mentor.id + idx) % 3) // 18..20
-        : isLateWeek
-          ? 17 + ((mentor.id + idx) % 3) // 17..19
-          : 10 + ((mentor.id + idx) % 4); // 10..13
-      const endHour = startHour + 1;
-      const start = `${String(startHour).padStart(2, '0')}:00`;
-      const end = `${String(endHour).padStart(2, '0')}:00`;
-      return { day, available, start, end };
-    });
-  }, [mentor.id]);
-
-  const resolveNextDateForDay = (day: string) => {
-    // Convert e.g. "Mon" => next matching local date.
-    const map: Record<string, number> = {
-      Mon: 1,
-      Tue: 2,
-      Wed: 3,
-      Thu: 4,
-      Fri: 5,
-      Sat: 6,
-      Sun: 0,
-    };
-    const targetDow = map[day] ?? 1;
-    const now = new Date();
-    const diff = (targetDow - now.getDay() + 7) % 7;
-    const date = new Date(now);
-    date.setDate(now.getDate() + diff);
-    return date;
-  };
-
-  const parseTimeToMinutes = (t: string) => {
-    const [hh, mm] = t.split(':').map(Number);
-    return hh * 60 + mm;
-  };
-
-  const formatMinutesDuration = (slot: { start: string; end: string }) => {
-    const startM = parseTimeToMinutes(slot.start);
-    const endM = parseTimeToMinutes(slot.end);
-    const mins = Math.max(30, endM - startM); // guard
-    return mins;
-  };
-
-  const slotStartEndAsDates = (slot: { day: string; start: string; end: string }) => {
-    const base = resolveNextDateForDay(slot.day);
-    const [sh, sm] = slot.start.split(':').map(Number);
-    const [eh, em] = slot.end.split(':').map(Number);
-
-    const startDt = new Date(base);
-    startDt.setHours(sh, sm, 0, 0);
-
-    const endDt = new Date(base);
-    endDt.setHours(eh, em, 0, 0);
-
-    return { start: startDt.toISOString(), end: endDt.toISOString() };
-  };
-
-  /** 1:1 booking end time follows chosen session length, not the slot window. */
-  const slotStartEndAsDatesWithDuration = (
-    slot: { day: string; start: string; end: string },
-    durationMinutes: number,
-  ) => {
-    const base = resolveNextDateForDay(slot.day);
-    const [sh, sm] = slot.start.split(':').map(Number);
-    const startDt = new Date(base);
-    startDt.setHours(sh, sm, 0, 0);
-    const endDt = new Date(startDt.getTime() + durationMinutes * 60_000);
-    return { start: startDt.toISOString(), end: endDt.toISOString() };
-  };
 
   const bio = useMemo(() => {
     return `Professor ${mentor.name} is a ${mentor.title} focused on ${mentor.field}. With ${mentor.experience} of experience, they guide students through research and real-world preparation across 1:1 sessions and seminars.`;
@@ -533,10 +373,10 @@ export default function ExpertProfile({
               </div>
 
               <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                  <h1 className="font-serif text-[2rem] font-medium text-[#1A3A4A] leading-tight">
-                    {mentor.name}
-                  </h1>
+                <h1 className="font-serif text-[2rem] font-medium text-[#1A3A4A] leading-tight">
+                  {mentor.name}
+                </h1>
+                <div className="mt-1.5">
                   <span className="inline-flex items-center gap-1 rounded-[3px] border border-slate-200 bg-slate-100 px-2 py-0.5 text-[12px] font-semibold tabular-nums text-slate-700">
                     <Users className="h-3.5 w-3.5" aria-hidden />
                     {displayFollowers.toLocaleString()} followers
@@ -813,10 +653,11 @@ export default function ExpertProfile({
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
                 <h2 className="font-serif text-[1.15rem] font-medium text-[#1A3A4A]">
-                  Book availability
+                  Book a 1:1 session
                 </h2>
                 <p className="mt-1 text-[12px] text-[#7A7A72]">
-                  Choose a service, pick a time on the expert&apos;s calendar, then continue to payment.
+                  Pick a time on the expert&apos;s calendar, then continue to payment. To join a
+                  seminar, use the Upcoming seminars list.
                 </p>
               </div>
               <span className="inline-flex items-center gap-1 rounded-[4px] bg-[#F5F3EF] px-2 py-1 text-[11px] font-semibold text-[#1A3A4A]">
@@ -828,138 +669,48 @@ export default function ExpertProfile({
             <div className="mt-4 space-y-4">
               <div>
                 <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#7A7A72] mb-2">
-                  Service offered
+                  Appointment Duration
                 </p>
-                <div className="flex flex-wrap gap-2">
-                  {supportsOneToOne && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setServiceChoice('oneToOne');
-                        setSelectedSlot(null);
-                        setBookingError(null);
-                        setSessionDurationMinutes(60);
-                      }}
-                      className={`rounded-[4px] border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
-                        serviceChoice === 'oneToOne'
-                          ? 'border-[#1A3A4A] bg-[#1A3A4A] text-white'
-                          : 'border-[#E5E2DB] bg-white text-[#1A3A4A] hover:bg-[#F5F3EF]'
-                      }`}
-                    >
-                      1:1 session
-                    </button>
-                  )}
-                  {supportsSeminar && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setServiceChoice('seminar');
-                        setSelectedSlot(null);
-                        setBookingError(null);
-                        setSessionDurationMinutes(60);
-                      }}
-                      className={`rounded-[4px] border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
-                        serviceChoice === 'seminar'
-                          ? 'border-[#1A3A4A] bg-[#1A3A4A] text-white'
-                          : 'border-[#E5E2DB] bg-white text-[#1A3A4A] hover:bg-[#F5F3EF]'
-                      }`}
-                    >
-                      Seminar
-                    </button>
-                  )}
-                </div>
+                {hasLockedDuration ? (
+                  <>
+                    <p className="inline-flex rounded-[4px] border border-[#1A3A4A] bg-[#1A3A4A] px-3 py-1.5 text-[12px] font-semibold text-white">
+                      {sessionDurationMinutes} min — fixed for this booking
+                    </p>
+                    <p className="mt-2 text-[11px] text-[#7A7A72]">
+                      Appointment duration is fixed after you select a time. Use Change time to
+                      choose a different length.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex flex-wrap gap-2">
+                      {offeredDurations.map(mins => (
+                        <button
+                          key={mins}
+                          type="button"
+                          onClick={() => applySessionDuration(mins)}
+                          className={`rounded-[4px] border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
+                            sessionDurationMinutes === mins
+                              ? 'border-[#1A3A4A] bg-[#1A3A4A] text-white'
+                              : 'border-[#E5E2DB] bg-white text-[#1A3A4A] hover:bg-[#F5F3EF]'
+                          }`}
+                        >
+                          {mins} min
+                        </button>
+                      ))}
+                    </div>
+                    <p className="mt-2 text-[11px] text-[#7A7A72]">
+                      Total uses the expert&apos;s hourly rate × appointment duration.
+                    </p>
+                  </>
+                )}
               </div>
-
-              {serviceChoice === 'oneToOne' && (
-                <div>
-                  <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#7A7A72] mb-2">
-                    Appointment Duration
-                  </p>
-                  {hasLockedDuration ? (
-                    <>
-                      <p className="inline-flex rounded-[4px] border border-[#1A3A4A] bg-[#1A3A4A] px-3 py-1.5 text-[12px] font-semibold text-white">
-                        {sessionDurationMinutes} min — fixed for this booking
-                      </p>
-                      <p className="mt-2 text-[11px] text-[#7A7A72]">
-                        Appointment duration is fixed after you select a time. Use Change time to
-                        choose a different length.
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <div className="flex flex-wrap gap-2">
-                        {offeredDurations.map(mins => (
-                          <button
-                            key={mins}
-                            type="button"
-                            onClick={() => applySessionDuration(mins)}
-                            className={`rounded-[4px] border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
-                              sessionDurationMinutes === mins
-                                ? 'border-[#1A3A4A] bg-[#1A3A4A] text-white'
-                                : 'border-[#E5E2DB] bg-white text-[#1A3A4A] hover:bg-[#F5F3EF]'
-                            }`}
-                          >
-                            {mins} min
-                          </button>
-                        ))}
-                      </div>
-                      <p className="mt-2 text-[11px] text-[#7A7A72]">
-                        Total uses the hourly rate for your slot (peak or off-peak) × appointment
-                        duration.
-                      </p>
-                    </>
-                  )}
-                </div>
-              )}
 
               <div>
                 <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#7A7A72] mb-2">
                   Availability
                 </p>
-                {serviceChoice === 'oneToOne' ? (
-                  bookingStep === 'review' ? (
-                    <div className="rounded-xl border border-[#E5E2DB] bg-white p-4 space-y-3">
-                      <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#7A7A72]">
-                        Booking summary
-                      </p>
-                      <dl className="space-y-2 text-sm text-[#1A3A4A]">
-                        <div className="flex justify-between gap-2">
-                          <dt className="text-[#7A7A72]">Expert</dt>
-                          <dd className="font-semibold text-right">{mentor.name}</dd>
-                        </div>
-                        <div className="flex justify-between gap-2">
-                          <dt className="text-[#7A7A72]">When</dt>
-                          <dd className="font-semibold text-right">{pickedSlotDisplay}</dd>
-                        </div>
-                        <div className="flex justify-between gap-2">
-                          <dt className="text-[#7A7A72]">Appointment duration</dt>
-                          <dd className="font-semibold">{pickedDuration} min</dd>
-                        </div>
-                        <div className="flex justify-between gap-2 border-t border-[#E5E2DB] pt-2">
-                          <dt className="text-[#7A7A72]">Total</dt>
-                          <dd className="font-serif text-lg font-semibold">
-                            ${oneToOneSessionPrice.toFixed(2)}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                  ) : bookingStep === 'pay' ? (
-                    <StudentBookingCheckout
-                      type="1:1 session"
-                      price={oneToOneSessionPrice}
-                      returnUrl={studentBookingReturnUrl}
-                      pendingDetails={{
-                        name: bookingEventTitle,
-                        start: pickedStart!.toISOString(),
-                        end: pickedEnd!.toISOString(),
-                        duration: pickedDuration,
-                        price: oneToOneSessionPrice,
-                        expert: String(expertDetails?._id ?? mentor.id),
-                      }}
-                      onPaymentSuccess={submitOneToOneBooking}
-                      onCancel={() => setBookingStep('review')}
-                    />
-                  ) : bookingStep === 'success' ? (
+                {bookingStep === 'success' ? (
                     <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4">
                       <p className="text-[14px] font-semibold text-emerald-900">
                         Session booked
@@ -1003,193 +754,22 @@ export default function ExpertProfile({
                       />
                     )}
                   </div>
-                  )
-                ) : (
-                <div className="grid grid-cols-2 gap-3">
-                  {availability.map(slot => {
-                    const active =
-                      selectedSlot?.day === slot.day &&
-                      selectedSlot?.start === slot.start &&
-                      selectedSlot?.end === slot.end;
-                    return (
-                      <button
-                        key={slot.day}
-                        type="button"
-                        disabled={!slot.available}
-                        onClick={() => {
-                          setSelectedSlot({ day: slot.day, start: slot.start, end: slot.end });
-                          setBookingError(null);
-                        }}
-                        className={`rounded-xl border px-3 py-3 text-left transition-colors ${
-                          !slot.available
-                            ? 'border-[#E5E2DB] bg-white opacity-60 cursor-not-allowed'
-                            : active
-                              ? 'border-[#1A3A4A] bg-[#F5F3EF] ring-2 ring-[#1A3A4A]/20'
-                              : 'border-[#E5E2DB] bg-[#F5F3EF] hover:bg-white'
-                        } ${active ? 'shadow-[0_10px_25px_rgba(26,58,74,0.10)]' : ''}`}
-                      >
-                        <div className="flex items-center justify-between">
-                          <span className="text-[12px] font-semibold">{slot.day}</span>
-                          {isPeakSlot(slot) ? (
-                            <span className="inline-flex items-center justify-center rounded-full bg-[#C9A84C]/25 px-2 py-0.5 text-[10px] font-semibold text-[#1A3A4A]">
-                              Peak
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center justify-center rounded-full bg-[#1A3A4A]/10 px-2 py-0.5 text-[11px] font-semibold text-[#1A3A4A]">
-                              <Clock className="h-3 w-3" aria-hidden />
-                            </span>
-                          )}
-                        </div>
-                        <div className="mt-2 text-[12px] font-semibold text-[#1A3A4A]">
-                          {slot.start} - {slot.end}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
                 )}
               </div>
-
-              {serviceChoice === 'oneToOne' &&
-                bookingStep === 'pick' &&
-                pickedStart &&
-                pickedEnd &&
-                pickedDuration ? (
-                <div
-                  data-testid="selected-slot-summary"
-                  className="rounded-xl border border-[#1A3A4A]/20 bg-[#E8F0F8] p-4 space-y-3"
-                >
-                  <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[#1A3A4A]">
-                    Your selected appointment
-                  </p>
-                  <dl className="space-y-2 text-sm text-[#1A3A4A]">
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-[#7A7A72]">When</dt>
-                      <dd className="font-semibold text-right">{pickedSlotDisplay}</dd>
-                    </div>
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-[#7A7A72]">Appointment duration</dt>
-                      <dd className="font-semibold">{pickedDuration} min</dd>
-                    </div>
-                    <div className="flex justify-between gap-2 border-t border-[#1A3A4A]/15 pt-2">
-                      <dt className="text-[#7A7A72]">Estimated total</dt>
-                      <dd className="font-serif text-lg font-semibold">
-                        ${oneToOneSessionPrice.toFixed(2)}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              ) : null}
 
               {bookingError && (
                 <div className="text-[12px] font-semibold text-red-600">{bookingError}</div>
               )}
 
-              {serviceChoice === 'oneToOne' ? (
-                bookingStep === 'success' ? (
-                  <button
-                    type="button"
-                    onClick={onBack}
-                    className="inline-flex w-full items-center justify-center rounded-[4px] border border-[#E5E2DB] bg-white px-4 py-3 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
-                  >
-                    Back to experts
-                  </button>
-                ) : bookingStep === 'pay' ? null : bookingStep === 'review' ? (
-                  <div className="flex flex-col gap-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (!pickedStart || !pickedEnd || !pickedDuration) {
-                          setBookingError('Please select a date and time on the calendar.');
-                          return;
-                        }
-                        setBookingError(null);
-                        setPaymentConfirmOpen(true);
-                      }}
-                      className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#1A3A4A] px-4 py-3 text-[13px] font-semibold text-white hover:bg-[#122635]"
-                    >
-                      Continue to payment
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        clearPickedSlot();
-                        void loadExpertDetails();
-                        setBookingStep('pick');
-                      }}
-                      className="inline-flex w-full items-center justify-center rounded-[4px] border border-[#E5E2DB] bg-white px-4 py-3 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
-                    >
-                      Change time
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (!pickedStart || !pickedEnd || !pickedDuration) {
-                        setBookingError('Please select a date and time on the calendar.');
-                        return;
-                      }
-                      setBookingError(null);
-                      setBookingStep('review');
-                    }}
-                    className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#1A3A4A] px-4 py-3 text-[13px] font-semibold text-white hover:bg-[#122635]"
-                  >
-                    Review booking
-                  </button>
-                )
-              ) : !bookingSuccess ? (
+              {bookingStep === 'success' ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    if (!selectedSlot) {
-                      setBookingError('Please select an available day/time slot.');
-                      return;
-                    }
-
-                    const duration = formatMinutesDuration(selectedSlot);
-                    const { start, end } = slotStartEndAsDates({
-                      day: selectedSlot.day,
-                      start: selectedSlot.start,
-                      end: selectedSlot.end,
-                    });
-
-                    const pending = {
-                      title: 'Seminar request',
-                      name: 'Seminar request',
-                      start,
-                      end,
-                      duration,
-                      price: selectedRate,
-                      expert: mentor.id,
-                      eventId: null,
-                      serviceChoice,
-                    };
-
-                    window.localStorage.setItem('pendingDetails', JSON.stringify(pending));
-                    setBookingSuccess(true);
-                  }}
-                  className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#234C6A] px-4 py-3 text-[13px] font-semibold text-white hover:brightness-110"
+                  onClick={onBack}
+                  className="inline-flex w-full items-center justify-center rounded-[4px] border border-[#E5E2DB] bg-white px-4 py-3 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
                 >
-                  Book availability
+                  Back to experts
                 </button>
-              ) : (
-                <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4">
-                  <div className="text-[14px] font-semibold text-emerald-900">
-                    Request saved.
-                  </div>
-                  <div className="mt-1 text-[12px] text-emerald-800">
-                    Next step (payment) will be handled later.
-                  </div>
-                  <button
-                    type="button"
-                    onClick={onBack}
-                    className="mt-3 w-full rounded-[4px] border border-emerald-200 bg-white px-3 py-2 text-[12px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
-                  >
-                    Back to experts
-                  </button>
-                </div>
-              )}
+              ) : null}
             </div>
           </section>
 
@@ -1214,7 +794,7 @@ export default function ExpertProfile({
                           per hour — {formatOfferedDurationsList(offeredDurations)} totals scale
                           from this rate
                         </p>
-                        {serviceChoice === 'oneToOne' && pickedStart && pickedEnd && pickedDuration ? (
+                        {pickedStart && pickedEnd && pickedDuration ? (
                           <p className="mt-2 text-[12px] font-semibold text-[#1A3A4A]">
                             {pickedDuration} min · ${oneToOneSessionPrice.toFixed(2)} · {pickedSlotDisplay}
                           </p>
@@ -1225,21 +805,6 @@ export default function ExpertProfile({
                     )}
                   </div>
                   <Star className="h-5 w-5 text-[#C9A84C]" aria-hidden />
-                </div>
-              </div>
-
-              <div className="rounded-xl border border-[#E5E2DB] bg-white px-4 py-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-[#7A7A72]">
-                      Seminar
-                    </p>
-                    <p className="mt-2 text-[20px] font-serif font-semibold text-[#1A3A4A]">
-                      ${seminarRate.toFixed(0)}
-                    </p>
-                    <p className="mt-1 text-[12px] text-[#7A7A72]">per attendee (mock)</p>
-                  </div>
-                  <Star className="h-5 w-5 text-[#E07B54]" aria-hidden />
                 </div>
               </div>
             </div>
@@ -1260,25 +825,89 @@ export default function ExpertProfile({
         }
       />
     ) : null}
-    {paymentConfirmOpen && bookingConfirmationDetails ? (
-      <BookingConfirmationModal
-        open={paymentConfirmOpen}
-        onClose={() => setPaymentConfirmOpen(false)}
-        onConfirm={() => {
-          setPaymentConfirmOpen(false);
-          setBookingStep('pay');
+    {bookingStep === 'review' ? (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[#1A3A4A]/40 p-4 backdrop-blur-sm"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) changeOneToOneTime();
         }}
-        details={bookingConfirmationDetails}
-      />
+      >
+        <div className="my-auto w-full max-w-md">
+          <div className="rounded-2xl border border-[#E5E2DB] bg-white p-4 sm:p-6 space-y-4">
+            <p className="font-serif text-lg font-medium text-[#1A3A4A]">Review your booking</p>
+            <dl className="space-y-2 text-sm text-[#1A3A4A]">
+              <div className="flex justify-between gap-2">
+                <dt className="text-[#7A7A72]">Expert</dt>
+                <dd className="font-semibold text-right">{mentor.name}</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="text-[#7A7A72]">When</dt>
+                <dd className="font-semibold text-right">{pickedSlotDisplay}</dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="text-[#7A7A72]">Appointment duration</dt>
+                <dd className="font-semibold">{pickedDuration} min</dd>
+              </div>
+              <div className="flex justify-between gap-2 border-t border-[#E5E2DB] pt-2">
+                <dt className="text-[#7A7A72]">Total</dt>
+                <dd className="font-serif text-lg font-semibold">
+                  ${oneToOneSessionPrice.toFixed(2)}
+                </dd>
+              </div>
+            </dl>
+            <button
+              type="button"
+              onClick={() => setBookingStep('pay')}
+              className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#1A3A4A] px-4 py-3 text-[13px] font-semibold text-white hover:bg-[#122635]"
+            >
+              Continue to payment
+            </button>
+            <button
+              type="button"
+              onClick={changeOneToOneTime}
+              className="inline-flex w-full items-center justify-center rounded-[4px] border border-[#E5E2DB] px-4 py-2.5 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
+            >
+              Change time
+            </button>
+          </div>
+        </div>
+      </div>
+    ) : null}
+    {bookingStep === 'pay' ? (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[#1A3A4A]/40 p-4 backdrop-blur-sm"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setBookingStep('review');
+        }}
+      >
+        <div className="my-auto w-full max-w-lg">
+          <StudentBookingCheckout
+            type="1:1 session"
+            price={oneToOneSessionPrice}
+            returnUrl={studentBookingReturnUrl}
+            pendingDetails={{
+              name: bookingEventTitle,
+              start: pickedStart!.toISOString(),
+              end: pickedEnd!.toISOString(),
+              duration: pickedDuration,
+              price: oneToOneSessionPrice,
+              expert: String(expertDetails?._id ?? mentor.id),
+            }}
+            onPaymentSuccess={submitOneToOneBooking}
+            onCancel={() => setBookingStep('review')}
+            cancelLabel="Back"
+          />
+        </div>
+      </div>
     ) : null}
     {seminarCheckout ? (
       <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+        className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-[#1A3A4A]/40 p-4 backdrop-blur-sm"
         onClick={(e) => {
           if (e.target === e.currentTarget) setSeminarCheckout(null);
         }}
       >
-        <div className="w-full max-w-md">
+        <div className="my-auto w-full max-w-lg">
           <StudentBookingCheckout
             type="Seminar"
             price={seminarCheckout.price}
@@ -1297,4 +926,3 @@ export default function ExpertProfile({
     </>
   );
 }
-

--- a/FE/src/components/dashboard/PaymentHistoryTable.tsx
+++ b/FE/src/components/dashboard/PaymentHistoryTable.tsx
@@ -1,3 +1,6 @@
+
+
+
 import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { doGetCustomerPaymentHistory } from '../../api/api';
@@ -65,7 +68,7 @@ export function PaymentHistoryTable({ payments, loading, error, stickyHeader = f
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-left">
-        <thead className={`bg-slate-50 border-b border-slate-200${stickyHeader ? ' sticky top-0' : ''}`}>
+        <thead className={`bg-slate-50 border-b border-[#e8e6e1]${stickyHeader ? ' sticky top-0' : ''}`}>
           <tr>
             <th className={TH}>Receipt #</th>
             <th className={TH}>Date</th>

--- a/FE/src/components/dashboard/PaymentHistoryTable.tsx
+++ b/FE/src/components/dashboard/PaymentHistoryTable.tsx
@@ -1,6 +1,3 @@
-
-
-
 import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { doGetCustomerPaymentHistory } from '../../api/api';

--- a/FE/src/components/dashboard/StudentBookingCheckout.tsx
+++ b/FE/src/components/dashboard/StudentBookingCheckout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import {
   PaymentElement,
@@ -51,6 +51,41 @@ const CheckoutForm = ({
   const stripe = useStripe();
   const elements = useElements();
   const [errorMessage, setErrorMessage] = useState('');
+  // Animated progress shown under the Pay button while the charge is processing,
+  // so the student sees that the payment is working through to completion.
+  const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const progressTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearProgressTimer = () => {
+    if (progressTimer.current) {
+      clearInterval(progressTimer.current);
+      progressTimer.current = null;
+    }
+  };
+
+  const beginProgress = () => {
+    setProcessing(true);
+    setProgress(10);
+    clearProgressTimer();
+    // Ease toward ~90% while we wait on Stripe (true completion time is unknown).
+    progressTimer.current = setInterval(() => {
+      setProgress((p) => (p < 90 ? p + (90 - p) * 0.15 : p));
+    }, 350);
+  };
+
+  const endProgress = (success: boolean) => {
+    clearProgressTimer();
+    if (success) {
+      setProgress(100);
+      setTimeout(() => setProcessing(false), 450);
+    } else {
+      setProgress(0);
+      setProcessing(false);
+    }
+  };
+
+  useEffect(() => clearProgressTimer, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -71,6 +106,7 @@ const CheckoutForm = ({
       }
 
       SetLoadingStatus(true);
+      beginProgress();
 
       const response = await createStripePaymentIntent({
         stripeMode,
@@ -80,6 +116,7 @@ const CheckoutForm = ({
       if (!clientSecret) {
         setErrorMessage('Could not start payment. Please try again in a moment.');
         SetLoadingStatus(false);
+        endProgress(false);
         return;
       }
 
@@ -97,16 +134,22 @@ const CheckoutForm = ({
       SetLoadingStatus(false);
 
       if (paymentIntent?.status === 'succeeded') {
+        endProgress(true);
         window.localStorage.removeItem('pendingDetails');
         onPaymentSuccess(paymentIntent.id);
       } else if (paymentIntent) {
+        endProgress(false);
         window.localStorage.removeItem('pendingDetails');
         setErrorMessage('Payment failed, try again.');
+      } else {
+        // Redirect-based payment is taking over; show it as complete.
+        endProgress(true);
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Error while processing payment.';
       setErrorMessage(message);
       SetLoadingStatus(false);
+      endProgress(false);
     }
   };
 
@@ -120,13 +163,30 @@ const CheckoutForm = ({
     <form onSubmit={handleSubmit} className="space-y-4">
       <PaymentElement />
       <FormAlert variant="error" message={errorMessage} onDismiss={() => setErrorMessage('')} />
-      <button
-        type="submit"
-        disabled={!stripe || !elements}
-        className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#1A3A4A] px-4 py-3 text-[13px] font-semibold text-white hover:bg-[#122635] disabled:opacity-50"
-      >
-        {price > 0 ? `Pay $${price}` : 'Confirm booking'}
-      </button>
+      <div>
+        <button
+          type="submit"
+          disabled={!stripe || !elements || processing}
+          className="inline-flex w-full items-center justify-center rounded-[4px] bg-[#1A3A4A] px-4 py-3 text-[13px] font-semibold text-white hover:bg-[#122635] disabled:opacity-60"
+        >
+          {processing ? 'Processing payment…' : price > 0 ? `Pay $${price}` : 'Confirm booking'}
+        </button>
+        {/* Animated progress line under the button while the charge is processing. */}
+        <div
+          className="mt-2 h-1 w-full overflow-hidden rounded-full bg-[#1A3A4A]/10 transition-opacity duration-200"
+          style={{ opacity: processing ? 1 : 0 }}
+          role="progressbar"
+          aria-label="Payment progress"
+          aria-valuenow={Math.round(progress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="h-full rounded-full bg-[#234C6A]"
+            style={{ width: `${progress}%`, transition: 'width 0.35s ease' }}
+          />
+        </div>
+      </div>
     </form>
   );
 };
@@ -138,6 +198,7 @@ type Props = {
   returnUrl?: string;
   onPaymentSuccess: (paymentIntentId: string) => void;
   onCancel?: () => void;
+  cancelLabel?: string;
 };
 
 export default function StudentBookingCheckout({
@@ -147,6 +208,7 @@ export default function StudentBookingCheckout({
   returnUrl,
   onPaymentSuccess,
   onCancel,
+  cancelLabel = 'Back',
 }: Props) {
   const stripeReturnBase =
     returnUrl ?? `${window.location.pathname}${window.location.search}`;
@@ -208,7 +270,7 @@ export default function StudentBookingCheckout({
   }
 
   return (
-    <div className="rounded-2xl border border-[#E5E2DB] bg-white p-6">
+    <div className="rounded-2xl border border-[#E5E2DB] bg-white p-4 sm:p-6">
       <p className="font-serif text-lg font-medium text-[#1A3A4A]">
         Pay for your {type}
       </p>
@@ -216,22 +278,24 @@ export default function StudentBookingCheckout({
         Total: <span className="font-semibold text-[#1A3A4A]">${price}</span>
         {stripeMode === 'test' ? ' · test mode' : ''}
       </p>
-      <Elements stripe={stripePromise} options={options}>
-        <CheckoutForm
-          pendingDetails={pendingDetails}
-          stripeMode={stripeMode}
-          price={price}
-          returnUrl={stripeReturnBase}
-          onPaymentSuccess={onPaymentSuccess}
-        />
-      </Elements>
+      <div className="mt-4">
+        <Elements stripe={stripePromise} options={options}>
+          <CheckoutForm
+            pendingDetails={pendingDetails}
+            stripeMode={stripeMode}
+            price={price}
+            returnUrl={stripeReturnBase}
+            onPaymentSuccess={onPaymentSuccess}
+          />
+        </Elements>
+      </div>
       {onCancel ? (
         <button
           type="button"
           onClick={onCancel}
           className="mt-4 w-full rounded-[4px] border border-[#E5E2DB] py-2.5 text-[13px] font-semibold text-[#1A3A4A] hover:bg-[#F5F3EF]"
         >
-          Back
+          {cancelLabel}
         </button>
       ) : null}
     </div>

--- a/FE/src/components/dashboard/StudentExpertBookingPicker.test.tsx
+++ b/FE/src/components/dashboard/StudentExpertBookingPicker.test.tsx
@@ -162,7 +162,7 @@ describe('StudentExpertBookingPicker', () => {
       'title',
       'Jane Doe is not available on this date',
     );
-    expect(wrapper).toHaveClass('h-full', 'w-full');
+    expect(wrapper).toHaveClass('relative', 'h-full');
   });
 
   it('confirms filter-by-time slot on day click and shows selection banner', () => {

--- a/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
+++ b/FE/src/components/dashboard/StudentExpertBookingPicker.tsx
@@ -207,12 +207,13 @@ export default function StudentExpertBookingPicker({
   const expertTz = expert?.timeZone || 'UTC';
   const expertName = useMemo(() => expertDisplayName(expert), [expert]);
 
-  const viewerTz = resolveViewerTimeZone(
-    tzMode,
-    userDetails?.timeZone || detectUserTimeZone(),
-    expertTz,
-    customTz,
-  );
+  // Default the calendar to the viewer's actual zone. A saved timeZone of 'UTC'
+  // is the User-model default (often never set), so fall back to the detected
+  // browser zone rather than showing everything in UTC.
+  const savedTz = userDetails?.timeZone;
+  const studentTz = savedTz && savedTz !== 'UTC' ? savedTz : detectUserTimeZone();
+
+  const viewerTz = resolveViewerTimeZone(tzMode, studentTz, expertTz, customTz);
 
   useLayoutEffect(() => {
     onViewerTimeZoneChange?.(viewerTz);
@@ -446,13 +447,28 @@ export default function StudentExpertBookingPicker({
       toolbar: StudentBookingToolbar,
       dateCellWrapper: ({ value, children }: { value: Date; children: React.ReactElement }) => {
         const title = getBlockedDayTitle(value);
-        if (!title) return children;
-        return (
-          <div title={title} className="h-full w-full">
-            {Children.map(children, (child) => {
+        // "Today" follows the selected viewer timezone (same basis the calendar
+        // uses to disable past days), so picking e.g. India can advance it a day.
+        const isToday =
+          getViewerYmdFromCalendarDate(value) === toYMDInTimeZone(new Date(), viewerTz);
+        if (!title && !isToday) return children;
+        const wrapped = title
+          ? Children.map(children, (child) => {
               if (!React.isValidElement(child)) return child;
-              return React.cloneElement(child, { title });
-            })}
+              return React.cloneElement(child as React.ReactElement<any>, { title });
+            })
+          : children;
+        // Match react-big-calendar's own day-cell flex sizing (flex: 1 0 0%) so
+        // wrapping the cell doesn't collapse/shift it out of alignment with the
+        // date numbers in the content row.
+        return (
+          <div title={title} className="relative h-full" style={{ flex: '1 0 0%' }}>
+            {wrapped}
+            {isToday && (
+              <span className="pointer-events-none absolute bottom-1 left-1/2 -translate-x-1/2 rounded-full bg-[#1A3A4A] px-2 py-[2px] text-[9px] font-semibold leading-none text-white shadow-sm">
+                Today
+              </span>
+            )}
           </div>
         );
       },
@@ -470,7 +486,7 @@ export default function StudentExpertBookingPicker({
         }) => renderDateHeader(label, date, drilldownView, onDrillDown),
       },
     }),
-    [getBlockedDayTitle, renderDateHeader],
+    [getBlockedDayTitle, renderDateHeader, viewerTz],
   );
 
   const eventStyleGetter = (event: any, _s: any, end: Date) => {
@@ -578,7 +594,7 @@ export default function StudentExpertBookingPicker({
         mode={tzMode}
         customTimeZone={customTz}
         expertTimeZone={expertTz}
-        studentTimeZone={userDetails?.timeZone || detectUserTimeZone()}
+        studentTimeZone={studentTz}
         onModeChange={setTzMode}
         onCustomTimeZoneChange={setCustomTz}
       />

--- a/FE/src/components/dashboard/StudentPaymentHistory.tsx
+++ b/FE/src/components/dashboard/StudentPaymentHistory.tsx
@@ -5,16 +5,18 @@ export default function StudentPaymentHistory() {
   const { payments, loading, error } = usePaymentHistory();
 
   return (
-    <div className="px-6 py-7 max-w-5xl">
-      <div className="flex items-center gap-3 mb-6">
-        <CreditCard className="h-6 w-6 text-[#234C6A]" />
-        <h2 className="text-2xl font-semibold text-slate-900">Payment History</h2>
-      </div>
+    <div className="h-[calc(100vh-56px)] overflow-y-auto bg-[#F5F3EF] px-4 py-8 sm:px-6">
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="flex items-center gap-3 mb-6">
+          <CreditCard className="h-6 w-6 text-[#234C6A]" />
+          <h2 className="text-2xl font-semibold text-slate-900">Payment History</h2>
+        </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
-        <PaymentHistoryTable payments={payments} loading={loading} error={error} />
-        <div className="border-t border-slate-200 px-6 py-3 bg-slate-50 text-sm text-slate-600">
-          <PaymentHistorySummary payments={payments} loading={loading} />
+        <div className="overflow-hidden rounded-2xl border border-[#e8e6e1] bg-white shadow-[0_10px_30px_rgba(0,0,0,0.06)]">
+          <PaymentHistoryTable payments={payments} loading={loading} error={error} />
+          <div className="border-t border-[#e8e6e1] px-6 py-3 bg-slate-50 text-sm text-slate-600">
+            <PaymentHistorySummary payments={payments} loading={loading} />
+          </div>
         </div>
       </div>
     </div>

--- a/FE/src/components/dashboard/StudentSeminars.tsx
+++ b/FE/src/components/dashboard/StudentSeminars.tsx
@@ -33,7 +33,10 @@ async function mapSeminar(g: any): Promise<Seminar> {
   const hasStart = start && !Number.isNaN(start.getTime());
   const keywords = (g?.keywords || []).map((k: any) => k?.value).filter(Boolean);
   const serviceLabels = canonicalLabelsFromMixedServiceEntries(g?.services);
-  const image = await resolveProfileImageSrc(g?.admin?.image, 'small', profileImageFetch);
+  // Prefer the seminar's own cover image; only fall back to the host's photo when absent.
+  const image = g?.image
+    ? String(g.image)
+    : await resolveProfileImageSrc(g?.admin?.image, 'small', profileImageFetch);
   return {
     id: String(g?._id),
     title: g?.name || 'Seminar',
@@ -67,7 +70,7 @@ export default function StudentSeminars() {
   const [majorFilter, setMajorFilter] = useState<string>('all');
   const [tagFilter, setTagFilter] = useState<string>('all');
   const [selectedSeminar, setSelectedSeminar] = useState<Seminar | null>(null);
-  const [bookingStep, setBookingStep] = useState<1 | 2 | 3>(1);
+  const [bookingStep, setBookingStep] = useState<1 | 2>(1);
   const [selectedTime, setSelectedTime] = useState<string>('');
   const [paying, setPaying] = useState(false);
   const [bookingDone, setBookingDone] = useState(false);
@@ -447,7 +450,11 @@ export default function StudentSeminars() {
                   returnUrl={seminarReturnUrl}
                   pendingDetails={{ groupChatId: s.id, price: s.price, name: s.title }}
                   onPaymentSuccess={joinSeminar}
-                  onCancel={() => setPaying(false)}
+                  onCancel={() => {
+                    setPaying(false);
+                    setBookingStep(2);
+                  }}
+                  cancelLabel="Change time"
                 />
                 {bookingError ? (
                   <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-medium text-rose-700">
@@ -458,7 +465,7 @@ export default function StudentSeminars() {
             ) : (
               <div className="mt-4 space-y-4">
                 <div className="rounded-lg border border-[#E5E2DB] bg-[#F5F3EF] px-3 py-2 text-[12px] text-[#1A3A4A]">
-                  Step {bookingStep} of 3
+                  Step {bookingStep} of 2
                 </div>
 
                 {bookingStep === 1 && (
@@ -499,32 +506,6 @@ export default function StudentSeminars() {
                       <button
                         type="button"
                         onClick={() => setBookingStep(1)}
-                        className="flex-1 rounded-[4px] border border-[#E5E2DB] bg-white px-3 py-2 text-sm font-semibold text-slate-700"
-                      >
-                        Back
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setBookingStep(3)}
-                        className="flex-1 rounded-[4px] bg-[#234C6A] px-3 py-2 text-sm font-semibold text-white hover:brightness-110"
-                      >
-                        Continue
-                      </button>
-                    </div>
-                  </div>
-                )}
-
-                {bookingStep === 3 && (
-                  <div className="space-y-3">
-                    <p className="text-sm text-[#7A7A72]">
-                      {s.price > 0
-                        ? `Confirm and pay $${s.price.toFixed(2)} to reserve your seat.`
-                        : 'Confirm to reserve your seat — this seminar is free.'}
-                    </p>
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setBookingStep(2)}
                         className="flex-1 rounded-[4px] border border-[#E5E2DB] bg-white px-3 py-2 text-sm font-semibold text-slate-700"
                       >
                         Back
@@ -678,4 +659,3 @@ export default function StudentSeminars() {
     </div>
   );
 }
-

--- a/FE/src/components/dashboard/StudentSettings.test.tsx
+++ b/FE/src/components/dashboard/StudentSettings.test.tsx
@@ -10,22 +10,21 @@ vi.mock('../../api/api', () => ({
 
 import { doUpdateProfile } from '../../api/api';
 
-const store = configureStore({
-  reducer: {
-    auth: () => ({
-      userDetails: { timeZone: 'America/New_York' },
-    }),
-  },
-});
+const makeStore = (userDetails: Record<string, any>) =>
+  configureStore({
+    reducer: {
+      auth: () => ({ userDetails }),
+    },
+  });
 
 describe('StudentSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('persists timeZone on save', async () => {
+  it('persists timeZone and notification preferences on save', async () => {
     render(
-      <Provider store={store}>
+      <Provider store={makeStore({ timeZone: 'America/New_York' })}>
         <StudentSettings />
       </Provider>,
     );
@@ -34,10 +33,49 @@ describe('StudentSettings', () => {
     expect(select.value).toBe('America/New_York');
 
     fireEvent.change(select, { target: { value: 'Asia/Kolkata' } });
+    // Turn marketing emails on (default off) to prove toggles are sent.
+    fireEvent.click(
+      screen.getByRole('button', { name: /Product & newsletter emails/i }),
+    );
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
 
     await waitFor(() => {
-      expect(doUpdateProfile).toHaveBeenCalledWith({ timeZone: 'Asia/Kolkata' });
+      expect(doUpdateProfile).toHaveBeenCalledWith({
+        timeZone: 'Asia/Kolkata',
+        notificationPreferences: {
+          email: true,
+          push: true,
+          seminarReminders: true,
+          sessionReminders: true,
+          marketing: true,
+        },
+      });
     });
+  });
+
+  it('hydrates toggles from saved preferences', () => {
+    render(
+      <Provider
+        store={makeStore({
+          timeZone: 'UTC',
+          notificationPreferences: {
+            email: false,
+            push: true,
+            seminarReminders: false,
+            sessionReminders: true,
+            marketing: true,
+          },
+        })}
+      >
+        <StudentSettings />
+      </Provider>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Email notifications/i }),
+    ).toHaveAttribute('aria-pressed', 'false');
+    expect(
+      screen.getByRole('button', { name: /Product & newsletter emails/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/FE/src/components/dashboard/StudentSettings.tsx
+++ b/FE/src/components/dashboard/StudentSettings.tsx
@@ -6,11 +6,12 @@ import { detectUserTimeZone } from '../../utils/schedulingTimezone';
 
 export default function StudentSettings() {
   const { auth: { userDetails } } = useAppSelector((s: any) => s);
-  const [emailNotifications, setEmailNotifications] = useState(true);
-  const [pushNotifications, setPushNotifications] = useState(true);
-  const [seminarReminders, setSeminarReminders] = useState(true);
-  const [sessionReminders, setSessionReminders] = useState(true);
-  const [marketingEmails, setMarketingEmails] = useState(false);
+  const prefs = userDetails?.notificationPreferences;
+  const [emailNotifications, setEmailNotifications] = useState(prefs?.email ?? true);
+  const [pushNotifications, setPushNotifications] = useState(prefs?.push ?? true);
+  const [seminarReminders, setSeminarReminders] = useState(prefs?.seminarReminders ?? true);
+  const [sessionReminders, setSessionReminders] = useState(prefs?.sessionReminders ?? true);
+  const [marketingEmails, setMarketingEmails] = useState(prefs?.marketing ?? false);
   const [darkMode, setDarkMode] = useState(false);
   const [timeZone, setTimeZone] = useState(
     () => userDetails?.timeZone || detectUserTimeZone(),
@@ -24,6 +25,16 @@ export default function StudentSettings() {
     }
   }, [userDetails?.timeZone]);
 
+  // Hydrate toggles from the saved preferences once they load from the server.
+  useEffect(() => {
+    if (!prefs) return;
+    if (typeof prefs.email === 'boolean') setEmailNotifications(prefs.email);
+    if (typeof prefs.push === 'boolean') setPushNotifications(prefs.push);
+    if (typeof prefs.seminarReminders === 'boolean') setSeminarReminders(prefs.seminarReminders);
+    if (typeof prefs.sessionReminders === 'boolean') setSessionReminders(prefs.sessionReminders);
+    if (typeof prefs.marketing === 'boolean') setMarketingEmails(prefs.marketing);
+  }, [prefs]);
+
   const cardClass =
     'rounded-2xl border border-[#E5E2DB] bg-white p-5 shadow-[0_10px_30px_rgba(0,0,0,0.04)]';
 
@@ -34,7 +45,16 @@ export default function StudentSettings() {
 
   const handleSave = async () => {
     setSaveError('');
-    const ok = await doUpdateProfile({ timeZone });
+    const ok = await doUpdateProfile({
+      timeZone,
+      notificationPreferences: {
+        email: emailNotifications,
+        push: pushNotifications,
+        seminarReminders,
+        sessionReminders,
+        marketing: marketingEmails,
+      },
+    });
     if (ok) {
       setSaveMessage('Settings saved successfully.');
       window.setTimeout(() => setSaveMessage(''), 2200);
@@ -115,6 +135,7 @@ export default function StudentSettings() {
                   onClick={() => item.setEnabled((v: boolean) => !v)}
                   className={toggleClass(item.enabled)}
                   aria-pressed={item.enabled}
+                  aria-label={item.label}
                 >
                   <span
                     className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${

--- a/FE/src/components/scheduling/BookingTimeZoneControl.test.tsx
+++ b/FE/src/components/scheduling/BookingTimeZoneControl.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import BookingTimeZoneControl from './BookingTimeZoneControl';
 
 describe('BookingTimeZoneControl', () => {
-  it('defaults to mine mode and switches to expert', () => {
+  it('offers mine and custom modes, with no expert option', () => {
     const onModeChange = vi.fn();
     render(
       <BookingTimeZoneControl
@@ -15,8 +15,9 @@ describe('BookingTimeZoneControl', () => {
         onCustomTimeZoneChange={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /Expert/i }));
-    expect(onModeChange).toHaveBeenCalledWith('expert');
+    expect(screen.queryByRole('button', { name: /Expert/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Choose timezone/i }));
+    expect(onModeChange).toHaveBeenCalledWith('custom');
   });
 
   it('shows timezone select in custom mode', () => {

--- a/FE/src/components/scheduling/BookingTimeZoneControl.tsx
+++ b/FE/src/components/scheduling/BookingTimeZoneControl.tsx
@@ -23,7 +23,6 @@ const CUSTOM_TZ_TOOLTIP =
 const BookingTimeZoneControl: React.FC<BookingTimeZoneControlProps> = ({
   mode,
   customTimeZone,
-  expertTimeZone,
   studentTimeZone,
   onModeChange,
   onCustomTimeZoneChange,
@@ -58,17 +57,6 @@ const BookingTimeZoneControl: React.FC<BookingTimeZoneControlProps> = ({
           }`}
         >
           My timezone ({mine})
-        </button>
-        <button
-          type="button"
-          onClick={() => onModeChange('expert')}
-          className={`rounded-[4px] border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
-            mode === 'expert'
-              ? 'border-[#1A3A4A] bg-[#1A3A4A] text-white'
-              : 'border-[#E5E2DB] bg-white text-[#1A3A4A] hover:bg-white'
-          }`}
-        >
-          Expert ({expertTimeZone || 'UTC'})
         </button>
         <button
           type="button"

--- a/FE/src/components/ui/DatePickerField.tsx
+++ b/FE/src/components/ui/DatePickerField.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, Calendar as CalendarIcon } from 'lucide-react';
+import {
+  format,
+  parseISO,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  isSameMonth,
+  isSameDay,
+  isBefore,
+  startOfDay,
+  addMonths,
+  subMonths,
+} from 'date-fns';
+
+type Props = {
+  /** Selected date as YYYY-MM-DD (empty string when unset). */
+  value: string;
+  onChange: (value: string) => void;
+  /** Earliest selectable date as YYYY-MM-DD; earlier days are disabled. */
+  min?: string;
+  id?: string;
+  placeholder?: string;
+};
+
+const WEEKDAYS = [
+  { key: 'sun', label: 'S' },
+  { key: 'mon', label: 'M' },
+  { key: 'tue', label: 'T' },
+  { key: 'wed', label: 'W' },
+  { key: 'thu', label: 'T' },
+  { key: 'fri', label: 'F' },
+  { key: 'sat', label: 'S' },
+];
+
+/**
+ * Brand-styled month calendar popover. Drop-in replacement for a native
+ * <input type="date">: emits/accepts a YYYY-MM-DD string. Colors match the
+ * student booking calendar so date selection looks consistent site-wide.
+ */
+export default function DatePickerField({
+  value,
+  onChange,
+  min,
+  id,
+  placeholder = 'Select a date',
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const selected = value ? parseISO(value) : null;
+  const [viewMonth, setViewMonth] = useState<Date>(selected ?? new Date());
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // Jump the visible month to the selected date when it changes externally.
+  useEffect(() => {
+    if (value) setViewMonth(parseISO(value));
+  }, [value]);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const minDate = min ? startOfDay(parseISO(min)) : null;
+
+  const gridDays = eachDayOfInterval({
+    start: startOfWeek(startOfMonth(viewMonth)),
+    end: endOfWeek(endOfMonth(viewMonth)),
+  });
+
+  const handlePick = (day: Date) => {
+    onChange(format(day, 'yyyy-MM-dd'));
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(v => !v)}
+        className="flex w-full items-center justify-between rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#234C6A]"
+      >
+        <span className={selected ? 'text-gray-800' : 'text-gray-400'}>
+          {selected ? format(selected, 'EEE, MMM d, yyyy') : placeholder}
+        </span>
+        <CalendarIcon className="h-4 w-4 text-[#234C6A]" aria-hidden />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-2 w-[18rem] rounded-xl border border-[#E5E2DB] bg-white p-3 shadow-[0_20px_50px_rgba(26,58,74,0.15)]">
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setViewMonth(m => subMonths(m, 1))}
+              className="rounded-lg p-1.5 text-[#234C6A] hover:bg-[#F5F3EF]"
+              aria-label="Previous month"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="text-sm font-semibold text-[#1A3A4A]">
+              {format(viewMonth, 'MMMM yyyy')}
+            </span>
+            <button
+              type="button"
+              onClick={() => setViewMonth(m => addMonths(m, 1))}
+              className="rounded-lg p-1.5 text-[#234C6A] hover:bg-[#F5F3EF]"
+              aria-label="Next month"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="mb-1 grid grid-cols-7 gap-1 text-center text-[11px] font-semibold uppercase tracking-wide text-[#7A7A72]">
+            {WEEKDAYS.map(d => (
+              <span key={d.key}>{d.label}</span>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {gridDays.map(day => {
+              const inMonth = isSameMonth(day, viewMonth);
+              const isSelected = selected ? isSameDay(day, selected) : false;
+              const isToday = isSameDay(day, new Date());
+              const disabled = minDate ? isBefore(startOfDay(day), minDate) : false;
+              return (
+                <button
+                  key={day.toISOString()}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => handlePick(day)}
+                  className={[
+                    'h-9 w-9 rounded-lg text-sm transition-colors',
+                    isSelected
+                      ? 'bg-[#1A3A4A] font-semibold text-white'
+                      : disabled
+                        ? 'cursor-not-allowed text-gray-300'
+                        : inMonth
+                          ? 'text-[#1A3A4A] hover:bg-[#E8F0F8]'
+                          : 'text-gray-400 hover:bg-[#F5F3EF]',
+                    !isSelected && isToday ? 'ring-1 ring-[#234C6A]/40' : '',
+                  ].join(' ')}
+                >
+                  {format(day, 'd')}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/FE/src/components/ui/SelectField.tsx
+++ b/FE/src/components/ui/SelectField.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+export type SelectOption = { value: string; label: string };
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  id?: string;
+  placeholder?: string;
+};
+
+/**
+ * Brand-styled select dropdown. Matches DatePickerField / TimePickerField:
+ * a trigger button plus a fixed-height, scrollable list that always opens
+ * downward (native <select> can't cap its popup height or direction).
+ */
+export default function SelectField({
+  value,
+  onChange,
+  options,
+  id,
+  placeholder = 'Select…',
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+
+  const selected = options.find(o => o.value === value);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  // Scroll the selected option into view when the list opens.
+  useEffect(() => {
+    if (open && selectedRef.current) {
+      selectedRef.current.scrollIntoView({ block: 'center' });
+    }
+  }, [open]);
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(v => !v)}
+        className="flex w-full items-center justify-between rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#234C6A]"
+      >
+        <span className={selected ? 'text-gray-800' : 'text-gray-400'}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronDown className="h-4 w-4 text-[#234C6A]" aria-hidden />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-2 max-h-60 w-full overflow-y-auto rounded-xl border border-[#E5E2DB] bg-white p-1.5 shadow-[0_20px_50px_rgba(26,58,74,0.15)]">
+          {options.map(opt => {
+            const isSelected = opt.value === value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                ref={isSelected ? selectedRef : undefined}
+                onClick={() => {
+                  onChange(opt.value);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                  isSelected
+                    ? 'bg-[#1A3A4A] font-semibold text-white'
+                    : 'text-[#1A3A4A] hover:bg-[#E8F0F8]'
+                }`}
+              >
+                <span>{opt.label}</span>
+                {isSelected ? <Check className="h-4 w-4 shrink-0" aria-hidden /> : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/FE/src/components/ui/TimePickerField.tsx
+++ b/FE/src/components/ui/TimePickerField.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from 'react';
+import { Clock } from 'lucide-react';
+
+const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1..12
+const MINUTES = Array.from({ length: 60 }, (_, i) => i); // 0..59
+
+type Props = {
+  /** Selected time as 24h "HH:mm" (empty string when unset). */
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  placeholder?: string;
+};
+
+type Period = 'AM' | 'PM';
+
+/** "14:30" -> { hour12: 2, minute: 30, period: 'PM' } */
+function parseTime(value: string): { hour12: number; minute: number; period: Period } {
+  if (!/^\d{1,2}:\d{2}$/.test(value)) {
+    return { hour12: 12, minute: 0, period: 'AM' };
+  }
+  const [h, m] = value.split(':').map(Number);
+  const period: Period = h < 12 ? 'AM' : 'PM';
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return { hour12, minute: m, period };
+}
+
+/** { hour12, minute, period } -> 24h "HH:mm" */
+function composeTime(hour12: number, minute: number, period: Period): string {
+  let h = hour12 % 12;
+  if (period === 'PM') h += 12;
+  return `${String(h).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+const to12h = (value: string): string => {
+  const { hour12, minute, period } = parseTime(value);
+  return `${hour12}:${String(minute).padStart(2, '0')} ${period}`;
+};
+
+/**
+ * Small custom dropdown that always opens downward with a fixed-height,
+ * scrollable list (native <select> can't cap its popup height/direction).
+ */
+function ScrollSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  format = String,
+}: {
+  value: number;
+  options: number[];
+  onChange: (value: number) => void;
+  ariaLabel: string;
+  format?: (n: number) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (open && selectedRef.current) {
+      selectedRef.current.scrollIntoView({ block: 'center' });
+    }
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => setOpen(v => !v)}
+        className="w-14 rounded-md border border-gray-200 px-3 py-2 text-center text-lg font-semibold tabular-nums text-[#1A3A4A] focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#234C6A]"
+      >
+        {format(value)}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 max-h-44 w-full overflow-y-auto rounded-md border border-[#E5E2DB] bg-white shadow-[0_12px_30px_rgba(26,58,74,0.15)]">
+          {options.map(o => {
+            const isSelected = o === value;
+            return (
+              <button
+                key={o}
+                type="button"
+                ref={isSelected ? selectedRef : undefined}
+                onClick={() => {
+                  onChange(o);
+                  setOpen(false);
+                }}
+                className={`block w-full px-3 py-1.5 text-center text-sm tabular-nums transition-colors ${
+                  isSelected
+                    ? 'bg-[#1A3A4A] font-semibold text-white'
+                    : 'text-[#1A3A4A] hover:bg-[#E8F0F8]'
+                }`}
+              >
+                {format(o)}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Brand-styled time picker popover. Drop-in replacement for a native
+ * <input type="time">: emits/accepts a 24h "HH:mm" string and supports any
+ * minute (hour : minute + AM/PM), just with styling that matches DatePickerField.
+ */
+export default function TimePickerField({
+  value,
+  onChange,
+  id,
+  placeholder = 'Select a time',
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  const { hour12, minute, period } = parseTime(value);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const emit = (h: number, m: number, p: Period) => onChange(composeTime(h, m, p));
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(v => !v)}
+        className="flex w-full items-center justify-between rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#234C6A]"
+      >
+        <span className={value ? 'text-gray-800' : 'text-gray-400'}>
+          {value ? to12h(value) : placeholder}
+        </span>
+        <Clock className="h-4 w-4 text-[#234C6A]" aria-hidden />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-2 w-full rounded-xl border border-[#E5E2DB] bg-white p-4 shadow-[0_20px_50px_rgba(26,58,74,0.15)]">
+          <div className="flex items-center justify-center gap-2">
+            {/* Hour */}
+            <ScrollSelect
+              ariaLabel="Hour"
+              value={hour12}
+              options={HOURS}
+              onChange={h => emit(h, minute, period)}
+            />
+
+            <span className="pb-0.5 text-lg font-semibold text-[#1A3A4A]">:</span>
+
+            {/* Minute */}
+            <ScrollSelect
+              ariaLabel="Minute"
+              value={minute}
+              options={MINUTES}
+              onChange={m => emit(hour12, m, period)}
+              format={n => String(n).padStart(2, '0')}
+            />
+
+            {/* AM / PM */}
+            <div className="ml-1 flex flex-col gap-1">
+              {(['AM', 'PM'] as Period[]).map(p => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => emit(hour12, minute, p)}
+                  className={`rounded-md px-3 py-1 text-sm font-semibold transition-colors ${
+                    period === p
+                      ? 'bg-[#1A3A4A] text-white'
+                      : 'border border-[#E5E2DB] text-[#1A3A4A] hover:bg-[#E8F0F8]'
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="mt-4 w-full rounded-lg bg-[#1A3A4A] py-2 text-sm font-semibold text-white hover:bg-[#122635]"
+          >
+            Done
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/FE/src/index.css
+++ b/FE/src/index.css
@@ -351,10 +351,6 @@ code {
   color: #1a3a4a !important;
 }
 
-.studentBookingCalendar .rbc-today {
-  background: #f5f3ef !important;
-}
-
 .studentBookingCalendar .rbc-date-cell {
   padding: 4px 6px;
   font-size: 13px;

--- a/FE/src/pages/Dashboard/_CustomerDashboard/profile.tsx
+++ b/FE/src/pages/Dashboard/_CustomerDashboard/profile.tsx
@@ -100,9 +100,12 @@ const CustomerProfile = ({
         set_phoneNumber(userDetails.phoneNumber)
     }
 
-    const mapServiceIds = (items: Array<any>) =>
+
+    const mapServiceValues = (items: Array<any>) =>
         items
-            .map((x: any) => (typeof x === 'string' ? x : x?._id ?? x?.id))
+            .map((x: any) =>
+                typeof x === 'string' ? x : x?.value ?? x?.label ?? x?.name,
+            )
             .filter(Boolean);
 
     const handleSavePhoto = async () => {
@@ -157,7 +160,7 @@ const CustomerProfile = ({
             email: userDetails.email,
             username: name,
             keywords: selectedKeywords,
-            services: mapServiceIds(selectedServices),
+            services: mapServiceValues(selectedServices),
             country,
             state,
             city,

--- a/FE/src/pages/Dashboard/_ExpertDashboard/ExpertSeminarHub.tsx
+++ b/FE/src/pages/Dashboard/_ExpertDashboard/ExpertSeminarHub.tsx
@@ -51,6 +51,8 @@ function mapGroupChatToExpertSeminar(g: any) {
     end: g.end,
     duration: g.duration,
     price: g.price,
+    image: g.image ?? null,
+    status: g.status,
   };
 }
 
@@ -88,13 +90,25 @@ function SeminarCard({
       className="group flex h-full flex-col rounded-2xl border border-[#e8e6e1] bg-white shadow-[0_12px_32px_rgba(15,23,42,0.08)] overflow-hidden transition-transform duration-150 hover:-translate-y-0.5 hover:shadow-[0_18px_44px_rgba(15,23,42,0.14)] cursor-pointer text-left"
     >
       <div className="relative h-36 w-full overflow-hidden bg-gradient-to-br from-[#234C6A] to-slate-800 sm:h-40">
-        <div className="absolute inset-0 flex items-center justify-center text-white/90">
-          <span className="text-3xl font-serif font-semibold opacity-90">
-            {(seminar?.name || 'S').slice(0, 1).toUpperCase()}
-          </span>
-        </div>
+        {seminar?.image ? (
+          <img
+            src={seminar.image}
+            alt={seminar?.name || 'Seminar cover'}
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-white/90">
+            <span className="text-3xl font-serif font-semibold opacity-90">
+              {(seminar?.name || 'S').slice(0, 1).toUpperCase()}
+            </span>
+          </div>
+        )}
         {badge ? (
-          <div className="absolute left-3 top-3 rounded-full bg-black/55 px-2.5 py-0.5 text-[10px] font-medium text-white backdrop-blur">
+          <div
+            className={`absolute left-3 top-3 rounded-full px-2.5 py-0.5 text-[10px] font-semibold text-white backdrop-blur ${
+              badge === 'Draft' ? 'bg-amber-500/90' : 'bg-black/55'
+            }`}
+          >
             {badge}
           </div>
         ) : null}
@@ -180,10 +194,18 @@ function SeminarDetailPane({
 
       <div className="max-w-6xl mx-auto grid gap-6 lg:grid-cols-[1fr_340px]">
         <section className="rounded-2xl border border-[#E5E2DB] bg-white overflow-hidden shadow-sm">
-          <div className="h-56 w-full bg-gradient-to-br from-[#234C6A] to-slate-900 sm:h-72 flex items-center justify-center">
-            <span className="text-5xl font-serif font-semibold text-white/90">
-              {(seminar?.name || 'S').slice(0, 1).toUpperCase()}
-            </span>
+          <div className="relative h-56 w-full bg-gradient-to-br from-[#234C6A] to-slate-900 sm:h-72 flex items-center justify-center">
+            {seminar?.image ? (
+              <img
+                src={seminar.image}
+                alt={seminar?.name || 'Seminar cover'}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-5xl font-serif font-semibold text-white/90">
+                {(seminar?.name || 'S').slice(0, 1).toUpperCase()}
+              </span>
+            )}
           </div>
           <div className="p-6">
             <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#7A7A72]">
@@ -405,7 +427,7 @@ export default function ExpertSeminarHub() {
     null,
   );
 
-  const mySeminars = useMemo(() => {
+  const allSeminars = useMemo(() => {
     const chats = (userDetails?.groupChats || []).filter(
       (g: any) => g && g.type === 'seminar',
     );
@@ -415,6 +437,22 @@ export default function ExpertSeminarHub() {
       return tb - ta;
     });
   }, [userDetails?.groupChats]);
+
+  // Drafts the host saved earlier but hasn't published — surfaced separately so
+  // they can be resumed; everything else shows in the main "Your seminars" list.
+  const myDrafts = useMemo(
+    () => allSeminars.filter((g: any) => g.status === 'draft' && getRefId(g.admin) === String(me)),
+    [allSeminars, me],
+  );
+  const mySeminars = useMemo(
+    () => allSeminars.filter((g: any) => g.status !== 'draft'),
+    [allSeminars],
+  );
+
+  const resumeDraft = (s: any) => {
+    setEditPayload(mapGroupChatToExpertSeminar(s));
+    setScreen('edit');
+  };
 
   const handleAfterSave = async () => {
     await (dispatch as any)(updateMe());
@@ -491,6 +529,27 @@ export default function ExpertSeminarHub() {
       </header>
 
       <div className="max-w-6xl mx-auto space-y-10">
+        {myDrafts.length > 0 ? (
+          <section>
+            <h2 className="text-lg font-semibold text-slate-900 mb-1">
+              Drafts <span className="text-slate-400">({myDrafts.length})</span>
+            </h2>
+            <p className="text-sm text-slate-600 mb-4">
+              Unfinished seminars saved earlier — select one to continue editing and publish.
+            </p>
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+              {myDrafts.map((s: any) => (
+                <SeminarCard
+                  key={s._id || getRefId(s)}
+                  seminar={s}
+                  onClick={() => resumeDraft(s)}
+                  badge="Draft"
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         <section>
           <h2 className="text-lg font-semibold text-slate-900 mb-1">Your seminars</h2>
           <p className="text-sm text-slate-600 mb-4">

--- a/FE/src/pages/Dashboard/_ExpertDashboard/calendar.tsx
+++ b/FE/src/pages/Dashboard/_ExpertDashboard/calendar.tsx
@@ -65,6 +65,12 @@ const ExpertCalendar: React.FC = () => {
       textColor = "#9ca3af";
     }
 
+    if (event.status === "draft") {
+      backgroundColor = "#fef3c7";
+      borderColor = "#fcd34d";
+      textColor = "#92400e";
+    }
+
     return {
       style: {
         backgroundColor,
@@ -170,13 +176,21 @@ const ExpertCalendar: React.FC = () => {
           g.status !== "pending" || !g.createdBy || iAmCreator;
 
         if (shouldPush) {
+          const start = g.start ? new Date(g.start) : null;
+          // A draft may be saved without a date yet — can't place it on the grid.
+          if (!start || Number.isNaN(start.getTime())) return;
           const isSeminar = g.type === "seminar";
+          const isDraft = g.status === "draft";
           temp.push({
             ...g,
             id: g._id,
-            start: new Date(g.start),
-            end: new Date(g.end),
-            title: isSeminar ? `(S) ${g.name}` : g.name || "1:1 session",
+            start,
+            end: g.end ? new Date(g.end) : start,
+            title: isSeminar
+              ? isDraft
+                ? `(Draft) ${g.name}`
+                : `(S) ${g.name}`
+              : g.name || "1:1 session",
             type: g.type,
             status: g.status,
           });

--- a/FE/src/pages/Dashboard/_ExpertDashboard/profile.tsx
+++ b/FE/src/pages/Dashboard/_ExpertDashboard/profile.tsx
@@ -168,9 +168,11 @@ const ExpertProfile = ({
         set_savingSpecialNote(false);
     };
 
-    const mapServiceIds = (items: Array<any>) =>
+    const mapServiceValues = (items: Array<any>) =>
         items
-            .map((x: any) => (typeof x === 'string' ? x : x?._id ?? x?.id))
+            .map((x: any) =>
+                typeof x === 'string' ? x : x?.value ?? x?.label ?? x?.name,
+            )
             .filter(Boolean);
 
     const handlePhotoFilePick = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -249,7 +251,7 @@ const ExpertProfile = ({
             title,
             description,
             keywords: selectedKeywords,
-            services: mapServiceIds(selectedServices),
+            services: mapServiceValues(selectedServices),
             country,
             state,
             city,

--- a/FE/src/pages/Dashboard/_ExpertDashboard/seminar.tsx
+++ b/FE/src/pages/Dashboard/_ExpertDashboard/seminar.tsx
@@ -8,12 +8,15 @@ import React, {
   import { useDispatch } from 'react-redux';
   import { useNavigate } from 'react-router-dom';
   import { useAppSelector } from '../../../store';
-  import { createGroupChat, updateGroupChat } from '../../../api/api';
+  import { createGroupChat, updateGroupChat, uploadSeminarCover } from '../../../api/api';
   import { SetLoadingStatus } from '../../../actions/appActions';
   import { showErrorAlert, showSuccessAlert, showWarningAlert } from '../../../actions/alertActions';
   import { updateMe } from '../../../actions/authActions';
   import { SERVICE_LABELS } from '../../../constants/serviceOptions';
-  
+  import DatePickerField from '../../../components/ui/DatePickerField';
+  import TimePickerField from '../../../components/ui/TimePickerField';
+  import SelectField from '../../../components/ui/SelectField';
+
   type StepId = 1 | 2 | 3;
   
   interface StepConfig {
@@ -51,6 +54,8 @@ import React, {
       end?: string | Date;
       duration?: number;
       price?: number;
+      image?: string | null;
+      status?: string;
     };
     /** New expert shell: refresh user + switch tab without full page navigation */
     onAfterSeminarSave?: () => void;
@@ -138,6 +143,8 @@ import React, {
     const [tagInput, setTagInput] = useState<string>('');
     const [errors, setErrors] = useState<SeminarErrors>({});
     const [coverPreview, setCoverPreview] = useState<string | null>(null);
+    // URL of an already-uploaded cover (when editing/resuming); reused if no new file is picked.
+    const [existingImageUrl, setExistingImageUrl] = useState<string | null>(null);
   
     useEffect(() => {
       if (userDetails?.status === 'review') {
@@ -171,6 +178,11 @@ import React, {
         ...prev,
         ...patched,
       }));
+
+      if (selectedSeminar.image) {
+        setExistingImageUrl(selectedSeminar.image);
+        setCoverPreview(selectedSeminar.image);
+      }
     }, [selectedSeminar]);
   
     const updateFormField = <K extends keyof SeminarFormData>(
@@ -195,6 +207,7 @@ import React, {
       }
       updateFormField('coverImage', file);
       if (file) {
+        setExistingImageUrl(null); // a new file replaces any previously uploaded cover
         const reader = new FileReader();
         reader.onload = () => {
           setCoverPreview(typeof reader.result === 'string' ? reader.result : null);
@@ -312,65 +325,76 @@ import React, {
       return { start, end, durationMinutes };
     };
   
-    const handlePublish = async () => {
-      if (!validateStep(3)) {
-        setCurrentStep(3);
+    // Shared save path for both "Publish" (status: active) and "Save as Draft"
+    // (status: draft). Publishing fully validates; a draft only needs a title.
+    const persistSeminar = async (status: 'active' | 'draft') => {
+      if (status === 'active') {
+        if (!validateStep(3)) {
+          setCurrentStep(3);
+          return;
+        }
+      } else if (!formData.title.trim()) {
+        setErrors((prev) => ({ ...prev, title: 'Add a title to save a draft.' }));
+        setCurrentStep(1);
         return;
       }
-  
-      const timeInfo = computeStartEndAndDuration();
-      if (!timeInfo) {
+
+      // Publishing requires a valid date/time; a draft may be saved without one.
+      let timeInfo = null;
+      if (formData.date && formData.startTime && formData.endTime) {
+        timeInfo = computeStartEndAndDuration();
+      }
+      if (status === 'active' && !timeInfo) {
         setCurrentStep(2);
         return;
       }
-  
-      const { start, end, durationMinutes } = timeInfo;
-  
-      const payload = {
-        name: formData.title.trim(),
-        description: formData.description.trim(),
-        services: formData.services,
-        keywords: formData.majors,
-        start,
-        end,
-        duration: durationMinutes,
-        price: formData.isFree ? 0 : Number(formData.price || 0),
-        type: 'seminar' as const,
-        status: 'active' as const,
-        createdBy: userDetails?._id,
-        maxAttendees: formData.maxAttendees === '' ? undefined : Number(formData.maxAttendees),
-        currency: formData.currency,
-        isRecurring: formData.isRecurring,
-        timezone: formData.timezone,
-      };
-  
+
       try {
         SetLoadingStatus(true);
-  
-        if (selectedSeminar?.groupId) {
-          const res = await updateGroupChat({
-            groupId: selectedSeminar.groupId,
-            ...payload,
-          });
-          if (res) {
-            dispatch(showSuccessAlert('Seminar updated successfully'));
-            await (dispatch as any)(updateMe());
-            if (onAfterSeminarSave) {
-              onAfterSeminarSave();
-            } else {
-              navigate(`${process.env.REACT_APP_AUTH_URL}expertdashboard/calendar`);
-            }
-          }
-        } else {
-          const res = await createGroupChat(payload);
-          if (res) {
-            dispatch(showSuccessAlert('Seminar created successfully'));
-            await (dispatch as any)(updateMe());
-            if (onAfterSeminarSave) {
-              onAfterSeminarSave();
-            } else {
-              navigate(`${process.env.REACT_APP_AUTH_URL}expertdashboard/calendar`);
-            }
+
+        // Upload a newly chosen cover; otherwise keep the existing one.
+        let imageUrl = existingImageUrl;
+        if (formData.coverImage) {
+          const uploaded = await uploadSeminarCover(formData.coverImage);
+          if (uploaded) imageUrl = uploaded;
+        }
+
+        const payload = {
+          name: formData.title.trim(),
+          description: formData.description.trim(),
+          image: imageUrl || undefined,
+          services: formData.services,
+          keywords: formData.majors,
+          start: timeInfo?.start,
+          end: timeInfo?.end,
+          duration: timeInfo?.durationMinutes,
+          price: formData.isFree ? 0 : Number(formData.price || 0),
+          type: 'seminar' as const,
+          status,
+          createdBy: userDetails?._id,
+          maxAttendees: formData.maxAttendees === '' ? undefined : Number(formData.maxAttendees),
+          currency: formData.currency,
+          isRecurring: formData.isRecurring,
+          timezone: formData.timezone,
+        };
+
+        const res = selectedSeminar?.groupId
+          ? await updateGroupChat({ groupId: selectedSeminar.groupId, ...payload })
+          : await createGroupChat(payload);
+
+        if (res) {
+          const msg =
+            status === 'draft'
+              ? 'Draft saved'
+              : selectedSeminar?.groupId
+                ? 'Seminar updated successfully'
+                : 'Seminar created successfully';
+          dispatch(showSuccessAlert(msg));
+          await (dispatch as any)(updateMe());
+          if (onAfterSeminarSave) {
+            onAfterSeminarSave();
+          } else {
+            navigate(`${process.env.REACT_APP_AUTH_URL}expertdashboard/calendar`);
           }
         }
       } catch {
@@ -379,10 +403,9 @@ import React, {
         SetLoadingStatus(false);
       }
     };
-  
-    const handleSaveDraft = () => {
-      dispatch(showWarningAlert('Draft saved locally. Publishing will be added next.'));
-    };
+
+    const handlePublish = () => persistSeminar('active');
+    const handleSaveDraft = () => persistSeminar('draft');
   
     const renderStepper = () => (
       <div className="mb-8 rounded-xl border border-gray-100 bg-white px-8 py-5">
@@ -450,6 +473,7 @@ import React, {
                     onClick={() => {
                       updateFormField('coverImage', null);
                       setCoverPreview(null);
+                      setExistingImageUrl(null);
                     }}
                     className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/80 text-gray-600 shadow hover:bg-white"
                   >
@@ -694,11 +718,12 @@ import React, {
           <label className="mb-1.5 block text-sm font-medium text-gray-700">
             Seminar Date <span className="text-red-400">*</span>
           </label>
-        <input
-          type="date"
+        <DatePickerField
+          id="seminar-date"
           value={formData.date}
-          onChange={(e) => updateFormField('date', e.target.value)}
-          className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-[#234C6A] focus:border-transparent"
+          onChange={(v) => updateFormField('date', v)}
+          min={new Date().toLocaleDateString('en-CA')}
+          placeholder="Select a date"
         />
           {errors.date && <p className="mt-1 text-xs text-red-500">{errors.date}</p>}
         </div>
@@ -708,11 +733,11 @@ import React, {
             <label className="mb-1.5 block text-sm font-medium text-gray-700">
               Start Time <span className="text-red-400">*</span>
             </label>
-          <input
-            type="time"
+          <TimePickerField
+            id="seminar-start-time"
             value={formData.startTime}
-            onChange={(e) => updateFormField('startTime', e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-[#234C6A] focus:border-transparent"
+            onChange={(v) => updateFormField('startTime', v)}
+            placeholder="Select start time"
           />
             {errors.startTime && (
               <p className="mt-1 text-xs text-red-500">{errors.startTime}</p>
@@ -722,11 +747,11 @@ import React, {
             <label className="mb-1.5 block text-sm font-medium text-gray-700">
               End Time <span className="text-red-400">*</span>
             </label>
-          <input
-            type="time"
+          <TimePickerField
+            id="seminar-end-time"
             value={formData.endTime}
-            onChange={(e) => updateFormField('endTime', e.target.value)}
-            className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-[#234C6A] focus:border-transparent"
+            onChange={(v) => updateFormField('endTime', v)}
+            placeholder="Select end time"
           />
             {errors.endTime && (
               <p className="mt-1 text-xs text-red-500">{errors.endTime}</p>
@@ -738,18 +763,13 @@ import React, {
           <label className="mb-1.5 block text-sm font-medium text-gray-700">
             Timezone <span className="text-red-400">*</span>
           </label>
-        <select
+        <SelectField
+          id="seminar-timezone"
           value={formData.timezone}
-          onChange={(e) => updateFormField('timezone', e.target.value)}
-          className="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-[#234C6A] focus:border-transparent"
-        >
-            <option value="">Select a timezone…</option>
-            {TIMEZONE_OPTIONS.map((tz) => (
-              <option key={tz} value={tz}>
-                {tz}
-              </option>
-            ))}
-          </select>
+          onChange={(v) => updateFormField('timezone', v)}
+          options={TIMEZONE_OPTIONS.map((tz) => ({ value: tz, label: tz }))}
+          placeholder="Select a timezone…"
+        />
           {errors.timezone && (
             <p className="mt-1 text-xs text-red-500">{errors.timezone}</p>
           )}

--- a/FE/src/pages/ExpertDashboard.tsx
+++ b/FE/src/pages/ExpertDashboard.tsx
@@ -105,11 +105,17 @@ export default function ExpertDashboard() {
     auth: { userDetails },
   } = useAppSelector((state) => state);
 
-  const [activeItem, setActiveItem] = useState('dashboard');
+  // Persist the active view so a refresh keeps the user on the same tab.
+  const [activeItem, setActiveItem] = useState(
+    () => window.localStorage.getItem('expertDashboardView') || 'dashboard',
+  );
+  useEffect(() => {
+    window.localStorage.setItem('expertDashboardView', activeItem);
+  }, [activeItem]);
   const [dmUnreadByRid, setDmUnreadByRid] = useState<Record<string, number>>({});
   const [rcRoomNameByRid, setRcRoomNameByRid] = useState<Record<string, string>>({});
   const [communityRidToName, setCommunityRidToName] = useState<Record<string, string>>({});
-  const [range, setRange] = useState<'today' | 'week' | 'all'>('today');
+  const [range, setRange] = useState<'today' | 'week' | 'all'>('all');
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
   const [expertUpcomingModal, setExpertUpcomingModal] = useState<{
     kind: 'seminar' | 'oneToOne';

--- a/FE/src/pages/FindExperts.tsx
+++ b/FE/src/pages/FindExperts.tsx
@@ -356,7 +356,9 @@ export default function FindExpertsPage({
                 >
                   <MentorCard
                     {...mentor}
-                    followerCount={followerCounts[String(mentor.id)] ?? 0}
+                    followerCount={
+                      followerCounts[String(mentor.id)] ?? mentor.followerCount ?? 0
+                    }
                     onViewProfile={onViewExpert}
                     isFollowing={followedMentorIds.some(
                       id => String(id) === String(mentor.id),
@@ -389,7 +391,9 @@ export default function FindExpertsPage({
                   key={String(mentor.id)}
                   {...mentor}
                   compact
-                  followerCount={followerCounts[String(mentor.id)] ?? 0}
+                  followerCount={
+                    followerCounts[String(mentor.id)] ?? mentor.followerCount ?? 0
+                  }
                   onViewProfile={onViewExpert}
                   isFollowing={followedMentorIds.some(
                     id => String(id) === String(mentor.id),

--- a/FE/src/pages/StudentDashboard.tsx
+++ b/FE/src/pages/StudentDashboard.tsx
@@ -424,7 +424,7 @@ export default function StudentDashboard() {
       );
       setFollowerCounts(fc => ({
         ...fc,
-        [id]: (fc[id] ?? 0) + (wasFollowing ? -1 : 1),
+        [id]: Math.max(0, (fc[id] ?? 0) + (wasFollowing ? -1 : 1)),
       }));
 
       const res = wasFollowing
@@ -445,7 +445,7 @@ export default function StudentDashboard() {
         );
         setFollowerCounts(fc => ({
           ...fc,
-          [id]: (fc[id] ?? 0) + (wasFollowing ? 1 : -1),
+          [id]: Math.max(0, (fc[id] ?? 0) + (wasFollowing ? 1 : -1)),
         }));
       }
     },

--- a/FE/src/pages/StudentDashboard.tsx
+++ b/FE/src/pages/StudentDashboard.tsx
@@ -23,7 +23,7 @@ import UpcomingCountdownCard, { type UpcomingSession } from '../components/dashb
 import UpcomingSessionModal, { type UpcomingModalSession } from '../components/dashboard/UpcomingSessionModal';
 import ExpertProfile from '../components/dashboard/ExpertProfile';
 import { completeStudentBookingFromStorage } from '../components/dashboard/StudentBookingCheckout';
-import { getExpertById } from '../api/api';
+import { getExpertById, doFollowExpert, doUnfollowExpert } from '../api/api';
 import type { MentorCardProps } from '../components/MentorCard';
 import { mapExpertToMentorWithImage } from '../utils/mapExpertToMentor';
 import StudentChat from '../components/dashboard/StudentChat';
@@ -271,7 +271,11 @@ function deriveModalSessions(
 
 /**
  * Find the soonest upcoming seminar and 1:1 from the user's real bookings,
- * for the "Upcoming sessions" countdown card.
+ * for the "Upcoming sessions" countdown card. Mirrors deriveSessionCounts /
+ * deriveModalSessions: seminars come from groupChats, but 1:1s live in two
+ * disjoint systems — student-booked individual groupChats ('active' = booked)
+ * and expert-created / legacy events (accepted/confirmed/approved) — so both
+ * are scanned for the next 1:1.
  */
 function deriveUpcomingSessions(u: any): {
   nextSeminar: UpcomingSession | null;
@@ -280,6 +284,13 @@ function deriveUpcomingSessions(u: any): {
   const now = Date.now();
   let nextSeminar: UpcomingSession | null = null;
   let nextOneToOne: UpcomingSession | null = null;
+
+  const considerOneToOne = (title: string, startAt: number) => {
+    if (!nextOneToOne || startAt < nextOneToOne.startAt) {
+      nextOneToOne = { title, startAt };
+    }
+  };
+
   for (const g of u?.groupChats || []) {
     const startAt = new Date(g?.start).getTime();
     if (Number.isNaN(startAt) || startAt <= now) continue;
@@ -290,10 +301,19 @@ function deriveUpcomingSessions(u: any): {
 
     if (isSeminar && (!nextSeminar || startAt < nextSeminar.startAt)) {
       nextSeminar = { title: g?.name || 'Seminar', startAt };
-    } else if (isSession && (!nextOneToOne || startAt < nextOneToOne.startAt)) {
-      nextOneToOne = { title: g?.name || '1:1 session', startAt };
+    } else if (isSession) {
+      considerOneToOne(g?.name || '1:1 session', startAt);
     }
   }
+
+  const CONFIRMED_EVENT = ['accepted', 'confirmed', 'approved'];
+  for (const e of u?.events || []) {
+    const startAt = new Date(e?.start).getTime();
+    if (Number.isNaN(startAt) || startAt <= now) continue;
+    if (!CONFIRMED_EVENT.includes((e?.status || '').toLowerCase())) continue;
+    considerOneToOne(e?.title || '1:1 session', startAt);
+  }
+
   return { nextSeminar, nextOneToOne };
 }
 
@@ -302,7 +322,15 @@ export default function StudentDashboard() {
   const dispatch = useDispatch();
   const location = useLocation();
   const navigate = useNavigate();
-  const [activeItem, setActiveItem] = useState('dashboard');
+  // Persist the active view so a refresh keeps the user where they were.
+  // 'expert-profile' depends on a selected expert that isn't restored on reload.
+  const [activeItem, setActiveItem] = useState(() => {
+    const saved = window.localStorage.getItem('studentDashboardView');
+    return saved && saved !== 'expert-profile' ? saved : 'dashboard';
+  });
+  useEffect(() => {
+    window.localStorage.setItem('studentDashboardView', activeItem);
+  }, [activeItem]);
   const [paymentReturnSuccess, setPaymentReturnSuccess] = useState(false);
   const [bookingReturnError, setBookingReturnError] = useState<string | null>(null);
   const [dmUnreadByRid, setDmUnreadByRid] = useState<Record<string, number>>({});
@@ -374,17 +402,55 @@ export default function StudentDashboard() {
     }
   }, [location.search, location.pathname, navigate, dispatch]);
 
-  const toggleExpertFollow = useCallback((mentorId: string | number) => {
-    const id = String(mentorId);
-    setFollowedMentorIds(prev => {
-      const isFollowing = prev.includes(id);
+  // Seed which experts the user already follows from their profile so the
+  // Follow buttons render in the correct state on load and after a refresh.
+  useEffect(() => {
+    const following = userDetails?.following;
+    if (!Array.isArray(following)) return;
+    setFollowedMentorIds(following.map((id: any) => String(id)));
+  }, [userDetails?.following]);
+
+  const toggleExpertFollow = useCallback(
+    async (mentorId: string | number) => {
+      // Auth guard: only a logged-in customer may follow.
+      if (!userDetails?.email) return;
+
+      const id = String(mentorId);
+      const wasFollowing = followedMentorIds.includes(id);
+
+      // Optimistic update — flip immediately, reconcile with the server below.
+      setFollowedMentorIds(prev =>
+        wasFollowing ? prev.filter(x => x !== id) : [...prev, id],
+      );
       setFollowerCounts(fc => ({
         ...fc,
-        [id]: (fc[id] ?? 0) + (isFollowing ? -1 : 1),
+        [id]: (fc[id] ?? 0) + (wasFollowing ? -1 : 1),
       }));
-      return isFollowing ? prev.filter(x => x !== id) : [...prev, id];
-    });
-  }, []);
+
+      const res = wasFollowing
+        ? await doUnfollowExpert(id)
+        : await doFollowExpert(id);
+
+      if (res && typeof res === 'object' && 'following' in res) {
+        // Reconcile with server truth (handles count drift / races).
+        setFollowedMentorIds(prev => {
+          const without = prev.filter(x => x !== id);
+          return res.following ? [...without, id] : without;
+        });
+        setFollowerCounts(fc => ({ ...fc, [id]: res.followerCount }));
+      } else {
+        // Request failed — revert the optimistic change.
+        setFollowedMentorIds(prev =>
+          wasFollowing ? [...prev, id] : prev.filter(x => x !== id),
+        );
+        setFollowerCounts(fc => ({
+          ...fc,
+          [id]: (fc[id] ?? 0) + (wasFollowing ? 1 : -1),
+        }));
+      }
+    },
+    [userDetails?.email, followedMentorIds],
+  );
   const [upcomingModal, setUpcomingModal] = useState<{
     kind: 'seminar' | 'oneToOne';
     status: 'booked' | 'pending';
@@ -505,10 +571,12 @@ export default function StudentDashboard() {
     (async () => {
       setCarouselLoading(true);
       try {
-        const filter = { username: '', name: '', keywords: [], services: [], sortBy: 'Name in ASC' };
+        // Carousel highlights the newest experts — BE "Recently joined" sorts by createdAt desc.
+        const expertFilter = { username: '', name: '', keywords: [], services: [], sortBy: 'Recently joined' };
+        const seminarFilter = { username: '', name: '', keywords: [], services: [], sortBy: 'Name in ASC' };
         const [expertRes, seminarRes]: [any, any] = await Promise.all([
-          doFilterExperts(filter),
-          doFilterSeminars(filter),
+          doFilterExperts(expertFilter),
+          doFilterSeminars(seminarFilter),
         ]);
         if (cancelled) return;
 
@@ -518,7 +586,7 @@ export default function StudentDashboard() {
         if (experts.length) {
           const mentors = await Promise.all(
             experts
-              .slice(0, 8)
+              .slice(0, 5)
               .map((e: any) => mapExpertToMentorWithImage(e, 'small')),
           );
           if (cancelled) return;

--- a/FE/src/pages/VerifyEmailChange.tsx
+++ b/FE/src/pages/VerifyEmailChange.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { CheckCircle, AlertCircle, Loader2, ArrowRight } from 'lucide-react';
+import { confirmEmailChange } from '../api/api';
+import { autoLogin } from '../actions/authActions';
+import FormAlert from '../components/FormAlert';
+
+const VerifyEmailChange = () => {
+    const { confirmCode } = useParams<{ confirmCode: string }>();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+    const [errorMsg, setErrorMsg] = useState('');
+    const hasVerified = useRef(false);
+
+    useEffect(() => {
+        if (!confirmCode || hasVerified.current) return;
+
+        const verify = async () => {
+            hasVerified.current = true;
+            try {
+                const response = await confirmEmailChange({ confirmCode });
+                if (response?.status === 'SUCCESS' && response.userDetails) {
+                    setStatus('success');
+                    dispatch(autoLogin() as any);
+                    setTimeout(() => {
+                        navigate(response.userDetails.role === 'customer'
+                            ? '/user/studentdashboard'
+                            : `/user/${response.userDetails.role}dashboard`);
+                    }, 2000);
+                } else {
+                    setStatus('error');
+                    setErrorMsg(response?.error || 'Confirmation failed. The link might be expired or invalid.');
+                }
+            } catch (err: any) {
+                setStatus('error');
+                setErrorMsg('An unexpected error occurred while confirming your email.');
+            }
+        };
+
+        verify();
+    }, [confirmCode, dispatch, navigate]);
+
+    return (
+        <div className="min-h-screen py-12 px-4 flex items-center justify-center bg-slate-50 relative">
+            <style>{`
+            .auth-dots-layer {
+                position: absolute; inset: 0; pointer-events: none; background-color: #F8FAFC;
+                background-image: radial-gradient(circle, rgba(188,204,220,0.45) 1.8px, transparent 1.8px);
+                background-size: 28px 28px;
+            }
+            .auth-dots-layer--animate { animation: authDotsDrift 35s linear infinite; }
+            @keyframes authDotsDrift { 0% { background-position: 0 0; } 100% { background-position: 28px 28px; } }
+            `}</style>
+
+            <div className="auth-dots-layer auth-dots-layer--animate" aria-hidden="true" />
+
+            <div className="relative z-10 w-full max-w-md bg-white p-8 rounded-3xl shadow-xl border border-slate-200 text-center text-slate-800">
+                {status === 'loading' && (
+                    <div className="flex flex-col items-center">
+                        <div className="w-16 h-16 bg-blue-50 text-[#234C6A] rounded-full flex items-center justify-center mb-6">
+                            <Loader2 className="w-8 h-8 animate-spin" />
+                        </div>
+                        <h2 className="text-2xl font-bold mb-2">Confirming your email</h2>
+                        <p className="text-slate-600">Please wait while we update your account...</p>
+                    </div>
+                )}
+
+                {status === 'success' && (
+                    <div className="flex flex-col items-center">
+                        <div className="w-16 h-16 bg-green-50 text-green-600 rounded-full flex items-center justify-center mb-6">
+                            <CheckCircle className="w-8 h-8" />
+                        </div>
+                        <h2 className="text-2xl font-bold mb-2">Email Confirmed!</h2>
+                        <p className="text-slate-600 mb-6">Your email is now set. Redirecting you to your dashboard...</p>
+                        <div className="w-full h-1 bg-slate-100 rounded-full overflow-hidden">
+                            <div className="h-full bg-green-500 rounded-full animate-[progress_2s_ease-in-out_forwards]" />
+                        </div>
+                        <style>{`@keyframes progress { 0% { width: 0% } 100% { width: 100% } }`}</style>
+                    </div>
+                )}
+
+                {status === 'error' && (
+                    <div className="flex flex-col items-center">
+                        <div className="w-16 h-16 bg-red-50 text-red-500 rounded-full flex items-center justify-center mb-6">
+                            <AlertCircle className="w-8 h-8" />
+                        </div>
+                        <h2 className="text-2xl font-bold mb-2">Confirmation Failed</h2>
+                        <FormAlert variant="error" message={errorMsg} className="mb-6 text-left" />
+                        <button
+                            onClick={() => navigate('/login')}
+                            className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-slate-100 text-slate-600 font-medium hover:bg-slate-200 transition-colors"
+                        >
+                            Return to Login <ArrowRight className="w-4 h-4" />
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default VerifyEmailChange;

--- a/FE/src/pages/WLProfileCompletion.tsx
+++ b/FE/src/pages/WLProfileCompletion.tsx
@@ -180,6 +180,11 @@ export default function WLProfileCompletion() {
 
             if (response === false) return;
             if (response.result || response.status === 'SUCCESS' || response.success) {
+                if (needsEmail && response.emailVerificationSent) {
+                    dispatch(showSuccessAlert(
+                        `We've sent a confirmation link to ${form.email.trim().toLowerCase()}. Click it to finish setting your email.`
+                    ));
+                }
                 // Refresh user details
                 await dispatch(autoLogin() as any);
                 const dashboardPath = role === 'customer' ? '/user/studentdashboard' : `/user/${role}dashboard`;
@@ -245,7 +250,7 @@ export default function WLProfileCompletion() {
                                 {errors.email ? (
                                     <p className="mt-1.5 text-xs text-red-500 font-medium">{errors.email}</p>
                                 ) : (
-                                    <p className="mt-1.5 text-xs text-slate-500">WeChat didn't share an email — add one so we can reach you and secure your account.</p>
+                                    <p className="mt-1.5 text-xs text-slate-500">WeChat didn't share an email — add one so we can reach you. We'll send a link to confirm it's yours.</p>
                                 )}
                             </div>
                         )}

--- a/FE/src/pages/WLProfileCompletion.tsx
+++ b/FE/src/pages/WLProfileCompletion.tsx
@@ -25,10 +25,15 @@ export default function WLProfileCompletion() {
     const { auth: { userDetails } } = useAppSelector((state) => state);
     
     // We expect the user to have been created by OAuth, so role should be present.
-    const role = userDetails?.role || 'customer'; 
+    const role = userDetails?.role || 'customer';
     const isExpert = role === 'expert';
 
+    // WeChat-only accounts get a synthetic wechat_<id>@wechat.local placeholder email
+    // (WeChat returns no email). Ask them to bind a real one here.
+    const needsEmail = String(userDetails?.email || '').toLowerCase().endsWith('@wechat.local');
+
     const [form, setForm] = useState({
+        email: '',                       // WeChat bind-email only
         majors: [] as string[],
         servicesOffered: [] as string[], // expert
         services: [] as string[],         // customer — same options as email/password sign-up
@@ -68,6 +73,11 @@ export default function WLProfileCompletion() {
     const toTitleCase = (str: string) => str.toLowerCase().split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 
     const validateField = (field: string, value: any) => {
+        if (field === 'email') {
+            if (!value.trim()) return 'Email is required';
+            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())) return 'Enter a valid email address';
+            return '';
+        }
         if (field === 'majors') return value.length === 0 ? 'Select at least one major' : '';
         if (isExpert) {
             if (field === 'title') return !value.trim() ? 'Title is required' : '';
@@ -128,6 +138,9 @@ export default function WLProfileCompletion() {
     const validate = () => {
         const e: Record<string, string> = {};
         const fieldsToValidate = ['majors'];
+        if (needsEmail) {
+            fieldsToValidate.push('email');
+        }
         if (isExpert) {
             fieldsToValidate.push('title', 'bio', 'servicesOffered');
         } else {
@@ -156,9 +169,10 @@ export default function WLProfileCompletion() {
             const data = {
                 keywords: form.majors,
                 services: isExpert ? form.servicesOffered : form.services,
-                ...(isExpert && { 
-                    title: form.title, 
-                    description: form.bio 
+                ...(needsEmail && { email: form.email.trim().toLowerCase() }),
+                ...(isExpert && {
+                    title: form.title,
+                    description: form.bio
                 })
             };
 
@@ -214,7 +228,28 @@ export default function WLProfileCompletion() {
 
                 <div className="bg-white rounded-3xl shadow-xl shadow-slate-200/50 p-6 sm:p-10 border border-slate-100">
                     <div className="space-y-6">
-                        
+
+                        {needsEmail && (
+                            <div>
+                                <label className="block text-sm font-semibold text-slate-700 mb-2">
+                                    Email Address <span className="text-red-500">*</span>
+                                </label>
+                                <input
+                                    type="email"
+                                    placeholder="you@example.com"
+                                    value={form.email}
+                                    onChange={e => handleChange('email', e.target.value)}
+                                    onBlur={() => handleBlur('email')}
+                                    className={errors.email ? inputError : inputNormal}
+                                />
+                                {errors.email ? (
+                                    <p className="mt-1.5 text-xs text-red-500 font-medium">{errors.email}</p>
+                                ) : (
+                                    <p className="mt-1.5 text-xs text-slate-500">WeChat didn't share an email — add one so we can reach you and secure your account.</p>
+                                )}
+                            </div>
+                        )}
+
                         {isExpert && (
                             <>
                                 <div>

--- a/FE/src/utils/mapExpertToMentor.ts
+++ b/FE/src/utils/mapExpertToMentor.ts
@@ -32,6 +32,13 @@ export function mapExpertToMentor(expert: any): MentorCardProps {
     isNew,
     resume: expert.resume ? String(expert.resume) : null,
     status: expert.status ? String(expert.status) : undefined,
+    followerCount:
+      typeof expert.followerCount === 'number'
+        ? expert.followerCount
+        : Array.isArray(expert.followers)
+          ? expert.followers.length
+          : 0,
+    isFollowing: !!expert.isFollowing,
   };
 }
 


### PR DESCRIPTION
WeChat OAuth:
- Before: users could only sign in with Google; anyone on WeChat had no way in.
- After: full server-side WeChat QR/web login. Since WeChat returns no email, new users get a placeholder account and are prompted to bind a real email during profile completion.

Follow system:
- Before: following an expert was local-only UI state that vanished on refresh, and follower counts were not real.
- After: following/followers persist on the User model via follow/unfollow endpoints; the UI updates optimistically and reconciles with server truth, so state and counts survive refresh.

Seminars (drafts + cover images):
- Before: "Save as Draft" only showed a fake "saved locally" toast, seminars had no cover image (just a letter tile), and the form used raw browser date/time/select inputs.
- After: drafts are persisted with a real draft status (hidden from students, shown in a dedicated Drafts section for experts), seminars support uploaded cover images everywhere, and inputs use styled picker components.

Rate limiting:
- Before: auth, payment, and analytics endpoints had no rate limiting and were open to brute-force/abuse.
- After: a baseline limiter (300/15min) plus a stricter limiter (50/15min) on sensitive routes - login, register, password reset, Stripe, payment history.

Booking & UX:
- Before: ExpertProfile booking used mock peak/off-peak pricing and fake availability, with an extra confirmation modal before checkout; the timezone picker defaulted to UTC and offered an "Expert timezone" option; dashboard tabs reset to "dashboard" on every refresh.
- After: removed all mock pricing/availability - 1:1 booking goes straight to a real checkout with a payment progress bar; the calendar defaults to the viewer's detected timezone with a "Today" badge; dashboards remember the active tab across refresh; notification preferences and timezone now save from settings.