### PR TITLE
Fix backend validation test fixtures

### DIFF
--- a/BE/tests/appendEvent.validation.test.ts
+++ b/BE/tests/appendEvent.validation.test.ts
@@ -26,14 +26,19 @@ const createRes = () => {
   return res;
 };
 
+const futureUtcDate = (daysFromNow: number, hourUtc: number) => {
+  const date = new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000);
+  date.setUTCHours(hourUtc, 0, 0, 0);
+  return date;
+};
+
 test("appendEvent rejects outside expert availability", async () => {
   const originalFindOne = User.findOne;
   const originalEventFind = Event.find;
   const originalGroupFind = GroupChat.find;
 
-  // Fixed UTC window (same calendar day) so CI is not flaky near midnight.
-  const start = new Date("2026-06-25T18:00:00.000Z");
-  const end = new Date("2026-06-25T19:00:00.000Z");
+  const start = futureUtcDate(14, 9);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
 
   try {
     User.findOne = async (query: any) => {

--- a/BE/tests/createGroupChatBooking.validation.test.ts
+++ b/BE/tests/createGroupChatBooking.validation.test.ts
@@ -38,14 +38,21 @@ const expertDoc = {
   populate: async () => {},
 };
 
+const futureUtcDate = (daysFromNow: number, hourUtc: number) => {
+  const date = new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000);
+  date.setUTCHours(hourUtc, 0, 0, 0);
+  return date;
+};
+
+const bookingStart = futureUtcDate(14, 9);
+
 const baseBody = {
   name: "Session",
   description: "d",
   services: [],
   keywords: [],
-  // Fixed UTC window (same calendar day) so CI is not flaky near midnight.
-  start: "2026-06-25T18:00:00.000Z",
-  end: "2026-06-25T19:00:00.000Z",
+  start: bookingStart.toISOString(),
+  end: new Date(bookingStart.getTime() + 60 * 60 * 1000).toISOString(),
   duration: 60,
   price: 0,
   expert: "expert-id-1",


### PR DESCRIPTION
## Summary
- Stabilize backend booking validation test fixtures by moving test bookings safely beyond the lead-time window
- Pin the test booking hour in UTC so blocked-date and availability assertions reach the intended validation paths

## Verification
- npm test in BE passes locally: 167 passing, 0 failing

## Notes
- Only backend test fixtures were changed.